### PR TITLE
Delete API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ There are several API endpoints:
 - [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of entity with given entity id
 - [`GET /entity/<entity_type>/<entity_id>/get/<attr_id>`](#get-attr-value): get attribute value
 - [`GET /entity/<entity_type>/<entity_id>/set/<attr_id>`](#set-attr-value): set attribute value
-- [`DELETE /entity/<entity_type>/<entity_id>`](#delete-eid-master-record): delete master record of entity with given id
+- [`DELETE /entity/<entity_type>/<entity_id>`](#delete-eid-data): delete entity data for given id
 - [`GET /entities`](#entities): list entity configuration
 - [`GET /control/<action>`](#control): send a pre-defined action into execution queue.
 
@@ -314,11 +314,11 @@ This endpoint is meant for `editable` plain attributes -- for direct user edit o
 
 ---
 
-## Delete Eid master record
+## Delete Eid data
 
-Delete master record with the specified `etype` and `eid`.
+Delete master record and snapshots with the specified `etype` and `eid`.
 
-Snapshots and raw datapoints are not deleted,
+Raw datapoints are not deleted,
 and the entity can be restored by sending new datapoints with the same `etype` and `eid`.
 
 ### Request

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@ There are several API endpoints:
 - [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of entity with given entity id
 - [`GET /entity/<entity_type>/<entity_id>/get/<attr_id>`](#get-attr-value): get attribute value
 - [`GET /entity/<entity_type>/<entity_id>/set/<attr_id>`](#set-attr-value): set attribute value
+- [`DELETE /entity/<entity_type>/<entity_id>`](#delete-eid-master-record): delete master record of entity with given id
 - [`GET /entities`](#entities): list entity configuration
 - [`GET /control/<action>`](#control): send a pre-defined action into execution queue.
 
@@ -313,6 +314,26 @@ This endpoint is meant for `editable` plain attributes -- for direct user edit o
 
 ---
 
+## Delete Eid master record
+
+Delete master record with the specified `etype` and `eid`.
+
+Snapshots and raw datapoints are not deleted,
+and the entity can be restored by sending new datapoints with the same `etype` and `eid`.
+
+### Request
+
+`DELETE /entity/<entity_type>/<entity_id>`
+
+### Response
+
+```json
+{
+  "detail": "OK"
+}
+```
+
+---
 ## Entities
 
 List entity types

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -168,3 +168,17 @@ async def set_eid_attr_value(
     # endpoint.
 
     return SuccessResponse()
+
+
+@router.delete("/{etype}/{eid}")
+async def delete_eid_record(etype: str, eid: str) -> SuccessResponse:
+    """Delete the master record of the specified entity.
+
+    Notice that this does not delete any raw datapoints,
+    or block the re-creation of the entity if new datapoints are received.
+    """
+    # Create a "delete" task and push it to task queue
+    task = DataPointTask(model_spec=MODEL_SPEC, etype=etype, eid=eid, delete=True)
+    TASK_WRITER.put_task(task, False)
+
+    return SuccessResponse()

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -172,7 +172,7 @@ async def set_eid_attr_value(
 
 @router.delete("/{etype}/{eid}")
 async def delete_eid_record(etype: str, eid: str) -> SuccessResponse:
-    """Delete the master record of the specified entity.
+    """Delete the master record and snapshots of the specified entity.
 
     Notice that this does not delete any raw datapoints,
     or block the re-creation of the entity if new datapoints are received.

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -42,6 +42,7 @@ class DataPointTask(Task):
         data_points: List of DataPoints to process
         tags: List of tags
         ttl_token: ...
+        delete: If True, delete entity
     """
 
     # Model specification just for internal validation. Discarded after that.
@@ -52,6 +53,7 @@ class DataPointTask(Task):
     data_points: list[DataPointBase] = []
     tags: list[Any] = []
     ttl_token: Optional[datetime] = None
+    delete: bool = False
 
     def routing_key(self):
         return f"{self.etype}:{self.eid}"

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -275,14 +275,20 @@ class EntityDatabase:
         except Exception as e:
             raise DatabaseError(f"Update of master records failed: {e}\n{records}") from e
 
-    def delete_master_record(self, etype: str, eid: str):
-        """Delete master record of `etype`:`eid`."""
+    def delete_eid(self, etype: str, eid: str):
+        """Delete master record and all snapshots of `etype`:`eid`."""
         master_col = self._master_col_name(etype)
+        snapshot_col = self._snapshots_col_name(etype)
         try:
             self._db[master_col].delete_one({"_id": eid})
-            self.log.debug("Deleted master record of %s.", eid)
+            self.log.debug("Deleted master record of %s/%s.", etype, eid)
         except Exception as e:
             raise DatabaseError(f"Delete of master record failed: {e}\n{eid}") from e
+        try:
+            res = self._db[snapshot_col].delete_many({"eid": eid})
+            self.log.debug("deleted %s snapshots of %s/%s.", res.deleted_count, etype, eid)
+        except Exception as e:
+            raise DatabaseError(f"Delete of snapshots failed: {e}\n{eid}") from e
 
     def delete_old_dps(self, etype: str, attr_name: str, t_old: datetime) -> None:
         """Delete old datapoints from master collection.

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -275,6 +275,15 @@ class EntityDatabase:
         except Exception as e:
             raise DatabaseError(f"Update of master records failed: {e}\n{records}") from e
 
+    def delete_master_record(self, etype: str, eid: str):
+        """Delete master record of `etype`:`eid`."""
+        master_col = self._master_col_name(etype)
+        try:
+            self._db[master_col].delete_one({"_id": eid})
+            self.log.debug("Deleted master record of %s.", eid)
+        except Exception as e:
+            raise DatabaseError(f"Delete of master record failed: {e}\n{eid}") from e
+
     def delete_old_dps(self, etype: str, attr_name: str, t_old: datetime) -> None:
         """Delete old datapoints from master collection.
 

--- a/dp3/task_processing/task_executor.py
+++ b/dp3/task_processing/task_executor.py
@@ -184,8 +184,8 @@ class TaskExecutor:
             )
             return False, []
         try:
-            self.log.debug("Task %s/%s: Deleting master record.", task.etype, task.eid)
-            self.db.delete_master_record(task.etype, task.eid)
+            self.log.debug("Task %s/%s: Deleting entity.", task.etype, task.eid)
+            self.db.delete_eid(task.etype, task.eid)
             self.elog.log("record_removed")
         except DatabaseError as e:
             self.log.error(f"Task {task.etype}/{task.eid}: DB error: {e}")


### PR DESCRIPTION
Adds API to delete selected entities to both the secondary modules and the external API. The delete action will remove the master record and all snapshots.

Changes overview:
- Added a new `delete: bool` field to DataPointTask
- Added a new `DELETE /entity/{etype}/{eid}` endpoint
- Added a functionality to `process_task` and EntityDatabase to perform the deletion itself
- Documented the new API endpoint