### PR TITLE
Entity Lifetimes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ There are several API endpoints:
 - [`GET /entity/<entity_type>/<entity_id>/get/<attr_id>`](#get-attr-value): get attribute value
 - [`GET /entity/<entity_type>/<entity_id>/set/<attr_id>`](#set-attr-value): set attribute value
 - [`DELETE /entity/<entity_type>/<entity_id>`](#delete-eid-data): delete entity data for given id
+- [`POST /entity/<entity_type>/<entity_id>/ttl`](#extend-ttls): extend TTLs of the specified entity
 - [`GET /entities`](#entities): list entity configuration
 - [`GET /control/<action>`](#control): send a pre-defined action into execution queue.
 
@@ -324,6 +325,39 @@ and the entity can be restored by sending new datapoints with the same `etype` a
 ### Request
 
 `DELETE /entity/<entity_type>/<entity_id>`
+
+### Response
+
+```json
+{
+  "detail": "OK"
+}
+```
+
+---
+
+## Extend TTLs
+
+Extend TTLs of the specified entity.
+
+Raw datapoints are not deleted,
+and the entity can be restored by sending new datapoints with the same `etype` and `eid`.
+
+### Request
+
+`POST /entity/<entity_type>/<entity_id>/ttl`
+
+The request body must be a dictionary of TTLs to extend, with string keys to identify the type of TTL.
+The values must be **UTC timestamps**, for example:
+
+```json
+{
+  "user_interaction": "2024-10-01T12:03:00",
+  "api_dependency": "2024-10-08T12:00:00"
+}
+```
+
+TTLs of the same name will be extended, and you add as many TTL names as you want.
 
 ### Response
 

--- a/docs/configuration/db_entities.md
+++ b/docs/configuration/db_entities.md
@@ -81,11 +81,12 @@ attribs:
 
 Entity is described simply by:
 
-| Parameter  | Data-type           | Default value | Description                                                                                                                               |
-|------------|---------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| **`id`**   | string (identifier) | *(mandatory)* | Short string identifying the entity type, it's machine name (must match regex `[a-zA-Z_][a-zA-Z0-9_-]*`). Lower-case only is recommended. |
-| **`name`** | string              | *(mandatory)* | Attribute name for humans. May contain any symbols.                                                                                       |
-| `snapshot` | bool                | *(mandatory)* | Whether to create snapshots of the entity. See [Architecture](../architecture.md#data-flow) for more details.                             |
+| Parameter      | Data-type           | Default value       | Description                                                                                                                               |
+|----------------|---------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **`id`**       | string (identifier) | *(mandatory)*       | Short string identifying the entity type, it's machine name (must match regex `[a-zA-Z_][a-zA-Z0-9_-]*`). Lower-case only is recommended. |
+| **`name`**     | string              | *(mandatory)*       | Attribute name for humans. May contain any symbols.                                                                                       |
+| **`snapshot`** | bool                | *(mandatory)*       | Whether to create snapshots of the entity. See [Architecture](../architecture.md#data-flow) for more details.                             |
+| `lifetime`     | `Lifetime Spec`     | `Immortal Lifetime` | Defines the lifetime of the entitiy, entities are never deleted by default. See the [Entity Lifetimes](lifetimes.md) for details.         |
 
 
 ## Attributes
@@ -97,12 +98,13 @@ Each attribute is specified by the following set of parameters:
 
 These apply to all types of attributes (plain, observations and timeseries).
 
-| Parameter     | Data-type           | Default value | Description                                                                                                                                  |
-|---------------|---------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| **`id`**      | string (identifier) | *(mandatory)* | Short string identifying the attribute, it's machine name (must match this regex `[a-zA-Z_][a-zA-Z0-9_-]*`). Lower-case only is recommended. |
-| **`type`**    | string              | *(mandatory)* | Type of attribute. Can be either `plain`, `observations` or `timeseries`.                                                                    |
-| **`name`**    | string              | *(mandatory)* | Attribute name for humans. May contain any symbols.                                                                                          |
-| `description` | string              | `""`          | Longer description of the attribute, if needed.                                                                                              |
+| Parameter     | Data-type           | Default value | Description                                                                                                                                                                                                                                       |
+|---------------|---------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`id`**      | string (identifier) | *(mandatory)* | Short string identifying the attribute, it's machine name (must match this regex `[a-zA-Z_][a-zA-Z0-9_-]*`). Lower-case only is recommended.                                                                                                      |
+| **`type`**    | string              | *(mandatory)* | Type of attribute. Can be either `plain`, `observations` or `timeseries`.                                                                                                                                                                         |
+| **`name`**    | string              | *(mandatory)* | Attribute name for humans. May contain any symbols.                                                                                                                                                                                               |
+| `ttl`         | timedelta           | `0`           | Optional extension of TTL of the entity, will be ignored if the [lifetime type](lifetimes.md#time-to-live-tokens) does not match. The time extension is calculated from `t2` if possible, otherwise from the current time (for plain attributes). |
+| `description` | string              | `""`          | Longer description of the attribute, if needed.                                                                                                                                                                                                   |
 
 
 ### Plain-specific parameters

--- a/docs/configuration/lifetimes.md
+++ b/docs/configuration/lifetimes.md
@@ -1,0 +1,130 @@
+# Entity Lifetimes
+
+There are currently three supported types of lifetimes:
+
+* **Immortal** - these entities are never removed unless explicitly ordered by the user. (default)
+* **Time-to-live tokens** - The platform will keep a list of TTL tokens for each entity, and will remove the entity when all tokens expire.
+* **Weak entities** - These entities are removed when they are no longer referenced by any other entity.
+
+Let us examine the options in detail.
+
+## Immortal entities
+
+Immortal entities are never removed unless explicitly ordered by the user.
+There are no special options for this lifetime type as of now, and this is the default lifetime type,
+i.e. it is used when no lifetime options are specified.
+
+An explicit configuration might look like this:
+
+```yaml
+entity:
+  id: bus_line
+  name: Bus Line
+  snapshot: false
+  lifetime:
+    type: immortal  # (1)!
+```
+
+1. Buses and drivers may change, but we do not remove the serviced bus lines
+
+## Time-to-live tokens
+
+The platform will keep a list of TTL tokens for each entity, and will remove the entity when all of its tokens expire.
+There are several options for this lifetime type:
+
+| Option name   | type        | default    | description                                                                                                                             |
+|---------------|-------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `on_create`   | `timedelta` | *required* | The base lifetime of an entity that is set on creation                                                                                  |
+| `mirror_data` | `bool`      | `True`     | If `True`, the lifetime of the entity is extended by the             `max_age` of the incoming observations and timeseries data-points. |
+
+TTL tokens can be attached to new data datapoints on per-attribute basis
+(see [attribute configuration](db_entities.md#base)),
+set to mirror the lifetime of the data (`mirror_data`),
+or sent explicitly using the API (see [`/entity/{etype}/{eid}/ttl`](../api.md#extend-ttls)).
+
+Here are a couple of examples of how this type of lifetime can be configured:
+
+### The Timer
+
+The entity will receive a TTL token on its creation, and will be automatically deleted after it expires.
+You can supplement this by explicitly extending the lifetime of the entity using the API, 
+or explicitly configuring a TTL on an attribute that will extend the lifetime.
+
+```yaml
+entity:
+  id: traffic_jam
+  name: Traffic Jam
+  snapshot: true
+  lifetime:
+    type: ttl
+    on_create: 1h
+    mirror_data: false
+```
+
+### Data-driven lifetime
+
+This is the default behavior of `mirror_data` option. The entity will be kept alive for as long as there are
+observations data for it. The lifetime of the entity will be extended by the `max_age` of the incoming data-points.
+
+```yaml
+entity:
+  id: passenger
+  name: Passenger 
+  snapshot: true
+  lifetime:
+    type: ttl
+    on_create: 30m  # (1)!
+    mirror_data: true
+```
+
+1. 30 minutes.
+
+### Mixture of both
+
+You can combine the two previous examples to create a lifetime that is extended by the incoming observation data,
+but has additional `ttl` set on incoming plain datapoints, or can be extended explicitly using the API.
+The lifetime of the entity will be extended using all the sources you choose to use.
+
+## Weak entities
+
+The entity will be removed when it is no longer referenced by any other entity.
+This is useful when you want to track some data that relates to multiple of your entities,
+but want to discard it if no such entity exists anymore.
+There are no special options for this lifetime type as of now.
+
+```yaml
+entity:
+  id: shared_ticket
+  name: Shared Ticket
+  snapshot: true
+  lifetime:
+    type: weak
+```
+
+
+??? warning "Remember the other side"
+
+    For the weak entity lifetime to work, there has to be a reference from an another entity,
+    for example:
+  
+    ```yaml
+    entity:
+      id: passenger
+      name: Passenger 
+      snapshot: true
+      lifetime:
+        type: ttl
+        on_create: 30m
+    attribs:
+      shared_tickets:
+        name: Shared Tickets
+        description: Tickets this passenger shares with other passengers.
+        type: observations
+        data_type: link<shared_ticket>
+        multi_value: true
+        history_params:
+          pre_validity: 0
+          post_validity: 0
+          max_age: 14d
+          aggregate: false
+    ```

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -241,8 +241,9 @@ on the data of the snapshot.
 
 The [`register_correlation_hook`][dp3.common.callback_registrar.CallbackRegistrar.register_correlation_hook]
 method expects a callable with the following signature: 
-`Callable[[str, dict], None]`, where the first argument is the entity type, and the second is a dict
+`Callable[[str, dict], Union[None, list[DataPointTask]]]`, where the first argument is the entity type, and the second is a dict
 containing the current values of the entity and its linked entities.
+The method can optionally return a list of DataPointTask objects to be inserted into the system.
 
 As correlation hooks can depend on each other, the hook inputs and outputs must be specified
 using the depends_on and may_change arguments. Both arguments are lists of lists of strings,

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -170,6 +170,18 @@ async def set_eid_attr_value(
     return SuccessResponse()
 
 
+@router.post("/{etype}/{eid}/ttl")
+async def extend_eid_ttls(etype: str, eid: str, body: dict[str, datetime]) -> SuccessResponse:
+    """Extend TTLs of the specified entity"""
+    # Construct task
+    task = DataPointTask(model_spec=MODEL_SPEC, etype=etype, eid=eid, ttl_tokens=body)
+
+    # Push tasks to task queue
+    TASK_WRITER.put_task(task, False)
+
+    return SuccessResponse()
+
+
 @router.delete("/{etype}/{eid}")
 async def delete_eid_record(etype: str, eid: str) -> SuccessResponse:
     """Delete the master record and snapshots of the specified entity.

--- a/dp3/common/attrspec.py
+++ b/dp3/common/attrspec.py
@@ -116,17 +116,29 @@ class AttrSpecGeneric(SpecModel, use_enum_values=True):
     """Base of attribute specification
 
     Parent of other `AttrSpec` classes.
+
+    Attributes:
+        ttl: Optional extension of TTL of the entity
+            - will be ignored if lifetime setting does not match.
     """
 
     id: constr(regex=ID_REGEX)
     name: str
     description: str = ""
+    ttl: Optional[timedelta] = None
 
     _dp_model = PrivateAttr()
 
     @property
     def dp_model(self) -> DataPointBase:
         return self._dp_model
+
+    @validator("ttl", pre=True)
+    def parse_timedelta(cls, v):
+        if v:
+            return parse_time_duration(v)
+        else:
+            return timedelta()
 
 
 class AttrSpecClassic(AttrSpecGeneric):

--- a/dp3/common/callback_registrar.py
+++ b/dp3/common/callback_registrar.py
@@ -120,7 +120,7 @@ class CallbackRegistrar:
 
     def register_correlation_hook(
         self,
-        hook: Callable[[str, dict], None],
+        hook: Callable[[str, dict], Union[None, list[DataPointTask]]],
         entity_type: str,
         depends_on: list[list[str]],
         may_change: list[list[str]],
@@ -134,7 +134,8 @@ class CallbackRegistrar:
 
         Args:
             hook: `hook` callable should expect entity type as str
-                and its current values, including linked entities, as dict
+                and its current values, including linked entities, as dict.
+                Can optionally return a list of DataPointTask objects to perform.
             entity_type: specifies entity type
             depends_on: each item should specify an attribute that is depended on
                 in the form of a path from the specified entity_type to individual attributes

--- a/dp3/common/datatype.py
+++ b/dp3/common/datatype.py
@@ -193,7 +193,7 @@ class DataType(BaseModel):
     def link_to(self) -> str:
         return self._link_to
 
-    def get_linked_entity(self) -> id:
+    def get_linked_entity(self) -> str:
         """Returns linked entity id. Raises ValueError if DataType is not a link."""
         try:
             return self._link_to

--- a/dp3/common/entityspec.py
+++ b/dp3/common/entityspec.py
@@ -1,8 +1,52 @@
-from pydantic import BaseModel, Extra
+from datetime import timedelta
+from typing import Literal, Union
+
+from pydantic import BaseModel, Extra, Field, validator
+
+from dp3.common.utils import parse_time_duration
 
 
 class SpecModel(BaseModel, extra=Extra.forbid):
     ...
+
+
+class ImmortalLifetime(SpecModel):
+    """Immortal lifetime specification.
+
+    The entity is never deleted.
+    """
+
+    type: Literal["immortal"]
+
+
+class TimeToLiveLifetime(SpecModel):
+    """TTL lifetime specification.
+
+    The entity is deleted after all of its TTL tokens expire.
+    TTL tokens can be attached to new data datapoints on per-attribute basis
+    (see [`AttrSpecGeneric`][dp3.common.attrspec.AttrSpecGeneric]),
+    set to mirror the lifetime of the data (`mirror_data`),
+    or sent explicitly using the API (see `/entity/{etype}/{eid}/ttl`).
+
+    Attributes:
+        on_create: The base lifetime of an entity.
+        mirror_data: If `True` (default), the lifetime of the entity is extended by the
+            `max_age` of the incoming observations and timeseries data-points.
+    """
+
+    type: Literal["ttl"]
+    on_create: timedelta
+    mirror_data: bool = True
+
+    @validator("on_create", pre=True)
+    def parse_timedelta(cls, v):
+        return parse_time_duration(v)
+
+
+class WeakLifetime(SpecModel):
+    """Weak entity lifetime specification"""
+
+    type: Literal["weak"]
 
 
 class EntitySpec(SpecModel):
@@ -14,5 +58,8 @@ class EntitySpec(SpecModel):
     id: str
     name: str
     snapshot: bool
+    lifetime: Union[ImmortalLifetime, TimeToLiveLifetime, WeakLifetime] = Field(
+        default_factory=lambda: ImmortalLifetime(type="immortal"), discriminator="type"
+    )
 
     description: str = ""

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -41,7 +41,7 @@ class DataPointTask(Task):
         eid: Entity id / key
         data_points: List of DataPoints to process
         tags: List of tags
-        ttl_token: ...
+        ttl_tokens: Dictionary of TTL tokens.
         delete: If True, delete entity
     """
 
@@ -52,7 +52,7 @@ class DataPointTask(Task):
     eid: str
     data_points: list[DataPointBase] = []
     tags: list[Any] = []
-    ttl_token: Optional[datetime] = None
+    ttl_tokens: Optional[dict[str, datetime]] = None
     delete: bool = False
 
     def routing_key(self):

--- a/dp3/common/utils.py
+++ b/dp3/common/utils.py
@@ -9,6 +9,13 @@ from typing import Union
 ipv4_re = re.compile(r"^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$")
 
 
+def entity_expired(utcnow: datetime, master_document: dict):
+    """Check if entity is expired (all TTLs are in the past)"""
+    if "#ttl" not in master_document:
+        return False
+    return all(ttl < utcnow for ttl in master_document["#ttl"].values())
+
+
 def ipstr2int(s):
     res = ipv4_re.match(s)
     if res is None:

--- a/dp3/core/collector.py
+++ b/dp3/core/collector.py
@@ -1,0 +1,156 @@
+"""
+Core module performing deletion of entities based on specified policy.
+"""
+import logging
+from datetime import datetime, timedelta
+from functools import partial
+
+from pydantic import BaseModel
+
+from dp3.common.attrspec import AttrType
+from dp3.common.base_module import BaseModule
+from dp3.common.callback_registrar import CallbackRegistrar
+from dp3.common.config import CronExpression, PlatformConfig
+from dp3.common.datapoint import DataPointBase, DataPointObservationsBase, DataPointTimeseriesBase
+from dp3.common.task import DataPointTask
+
+
+class CollectorConfig(BaseModel):
+    """The configuration of the Collector module.
+
+    Attributes:
+        collection_rate: The rate at which the collector module runs. Default is 3:00 AM every day.
+    """
+
+    collection_rate: CronExpression = CronExpression(hour="3", minute="0", second="0")
+
+
+class Collector(BaseModule):
+    """Collector module manages the lifetimes of entities based on specified policy."""
+
+    def __init__(
+        self, platform_config: PlatformConfig, module_config: dict, registrar: CallbackRegistrar
+    ):
+        self.log = logging.getLogger("Collector")
+        self.model_spec = platform_config.model_spec
+
+        for entity, entity_config in self.model_spec.entities.items():
+            lifetime = entity_config.lifetime
+            if lifetime.type == "immortal":
+                pass
+            elif lifetime.type == "ttl":
+                registrar.register_entity_hook(
+                    "on_entity_creation",
+                    partial(self.extend_ttl_on_create, base_ttl=lifetime.on_create),
+                    entity,
+                )
+
+                self._register_ttl_extensions(entity, registrar, lifetime.mirror_data)
+
+                # TODO register collection
+
+            elif lifetime.type == "weak":
+                pass  # TODO
+            else:
+                raise ValueError(f"Unknown lifetime type: {lifetime.type}")
+
+        registrar.register_attr_hook(
+            "on_new_observation",
+            partial(self.extend_observations_ttl, extend_by=timedelta(days=1)),
+            "test_entity_type",
+            "test_attr_type",
+        )
+
+    def extend_ttl_on_create(
+        self, eid: str, task: DataPointTask, base_ttl: timedelta
+    ) -> list[DataPointTask]:
+        """Extends the TTL of the entity by the specified timedelta."""
+        task = DataPointTask(
+            model_spec=self.model_spec,
+            etype=task.etype,
+            eid=eid,
+            ttl_tokens={"base": datetime.utcnow() + base_ttl},
+        )
+        return [task]
+
+    def _register_ttl_extensions(
+        self, entity: str, registrar: CallbackRegistrar, mirror_data: bool
+    ):
+        for attr, attr_spec in self.model_spec.entity_attributes[entity].items():
+            if attr_spec.t == AttrType.TIMESERIES:
+                if mirror_data and attr_spec.timeseries_params.max_age is not None:
+                    ttl = max(attr_spec.ttl, attr_spec.timeseries_params.max_age)
+                else:
+                    ttl = attr_spec.ttl
+                if not ttl:
+                    continue
+
+                registrar.register_attr_hook(
+                    "on_new_timeseries",
+                    partial(self.extend_timeseries_ttl, extend_by=ttl),
+                    entity,
+                    attr,
+                )
+            elif attr_spec.t == AttrType.OBSERVATIONS:
+                if mirror_data and attr_spec.history_params.max_age is not None:
+                    ttl = max(attr_spec.ttl, attr_spec.history_params.max_age)
+                else:
+                    ttl = attr_spec.ttl
+                if not ttl:
+                    continue
+
+                registrar.register_attr_hook(
+                    "on_new_observation",
+                    partial(self.extend_observations_ttl, extend_by=ttl),
+                    entity,
+                    attr,
+                )
+            elif attr_spec.t == AttrType.PLAIN:
+                if not attr_spec.ttl:
+                    continue
+
+                registrar.register_attr_hook(
+                    "on_new_plain",
+                    partial(self.extend_plain_ttl, extend_by=attr_spec.ttl),
+                    entity,
+                    attr,
+                )
+            else:
+                raise ValueError(f"Unknown attribute type: {attr_spec.t}")
+
+    def extend_plain_ttl(
+        self, eid: str, dp: DataPointBase, extend_by: timedelta
+    ) -> list[DataPointTask]:
+        """Extends the TTL of the entity by the specified timedelta."""
+        now = datetime.utcnow()
+        task = DataPointTask(
+            model_spec=self.model_spec,
+            etype=dp.etype,
+            eid=eid,
+            ttl_tokens={"data": now + extend_by},
+        )
+        return [task]
+
+    def extend_observations_ttl(
+        self, eid: str, dp: DataPointObservationsBase, extend_by: timedelta
+    ) -> list[DataPointTask]:
+        """Extends the TTL of the entity by the specified timedelta."""
+        task = DataPointTask(
+            model_spec=self.model_spec,
+            etype=dp.etype,
+            eid=eid,
+            ttl_tokens={"data": dp.t2 + extend_by},
+        )
+        return [task]
+
+    def extend_timeseries_ttl(
+        self, eid: str, dp: DataPointTimeseriesBase, extend_by: timedelta
+    ) -> list[DataPointTask]:
+        """Extends the TTL of the entity by the specified timedelta."""
+        task = DataPointTask(
+            model_spec=self.model_spec,
+            etype=dp.etype,
+            eid=eid,
+            ttl_tokens={"data": dp.t2 + extend_by},
+        )
+        return [task]

--- a/dp3/core/collector.py
+++ b/dp3/core/collector.py
@@ -90,21 +90,27 @@ class GarbageCollector:
         for attr, attr_spec in self.model_spec.entity_attributes[entity].items():
             if attr_spec.t == AttrType.TIMESERIES:
                 if mirror_data and attr_spec.timeseries_params.max_age is not None:
-                    ttl = max(attr_spec.ttl, attr_spec.timeseries_params.max_age)
+                    if attr_spec.ttl:
+                        ttl = max(attr_spec.ttl, attr_spec.timeseries_params.max_age)
+                    else:
+                        ttl = attr_spec.timeseries_params.max_age
                 else:
                     ttl = attr_spec.ttl
                 if not ttl:
                     continue
 
                 registrar.register_attr_hook(
-                    "on_new_timeseries",
+                    "on_new_ts_chunk",
                     partial(self.extend_timeseries_ttl, extend_by=ttl),
                     entity,
                     attr,
                 )
             elif attr_spec.t == AttrType.OBSERVATIONS:
                 if mirror_data and attr_spec.history_params.max_age is not None:
-                    ttl = max(attr_spec.ttl, attr_spec.history_params.max_age)
+                    if attr_spec.ttl:
+                        ttl = max(attr_spec.ttl, attr_spec.history_params.max_age)
+                    else:
+                        ttl = attr_spec.history_params.max_age
                 else:
                     ttl = attr_spec.ttl
                 if not ttl:

--- a/dp3/core/collector.py
+++ b/dp3/core/collector.py
@@ -207,7 +207,10 @@ class GarbageCollector:
 
         to_delete = []
         records_cursor = self.db.get_worker_master_records(
-            self.worker_index, self.num_workers, etype, fiter={"_id": {"$nin": have_references}}
+            self.worker_index,
+            self.num_workers,
+            etype,
+            query_filter={"_id": {"$nin": have_references}},
         )
         try:
             for master_document in records_cursor:
@@ -369,7 +372,12 @@ class GarbageCollector:
         )
 
     def remove_link_cache_of_deleted(self, entity: str, eid: str):
-        self.cache.delete_many({"from": f"{entity}#{eid}"})
+        self.cache.bulk_write(
+            [DeleteMany({"from": f"{entity}#{eid}"}), DeleteMany({"to": f"{entity}#{eid}"})]
+        )
 
     def remove_link_cache_of_deleted_many(self, entity: str, eids: list[str]):
-        self.cache.bulk_write([DeleteMany({"from": f"{entity}#{eid}"}) for eid in eids])
+        self.cache.bulk_write(
+            [DeleteMany({"from": f"{entity}#{eid}"}) for eid in eids]
+            + [DeleteMany({"to": f"{entity}#{eid}"}) for eid in eids]
+        )

--- a/dp3/core/collector.py
+++ b/dp3/core/collector.py
@@ -232,7 +232,7 @@ class GarbageCollector:
             increase={"entities": entities, "deleted": deleted},
         )
         self.log.info(
-            "Removal of '%s' entities by TTL done - %s processed, %s deleted",
+            "Removal of '%s' entities by TTL done - %s tracked, %s processed & deleted",
             etype,
             entities,
             deleted,

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -401,16 +401,16 @@ class EntityDatabase:
         return self._db[master_col].find({}, **kwargs)
 
     def get_worker_master_records(
-        self, worker_index: int, worker_cnt: int, etype: str, fiter: dict = None, **kwargs
+        self, worker_index: int, worker_cnt: int, etype: str, query_filter: dict = None, **kwargs
     ) -> pymongo.cursor.Cursor:
         """Get cursor to current master records of etype."""
         if etype not in self._db_schema_config.entities:
             raise DatabaseError(f"Entity '{etype}' does not exist")
 
-        fiter = {} if fiter is None else fiter
+        query_filter = {} if query_filter is None else query_filter
         master_col = self._master_col_name(etype)
         return self._db[master_col].find(
-            {"#hash": {"$mod": [worker_cnt, worker_index]}, **fiter}, **kwargs
+            {"#hash": {"$mod": [worker_cnt, worker_index]}, **query_filter}, **kwargs
         )
 
     def get_latest_snapshot(self, etype: str, eid: str) -> dict:

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -7,7 +7,7 @@ from typing import Literal, Optional, Union
 
 import pymongo
 from pydantic import BaseModel, Field, validator
-from pymongo import ReplaceOne
+from pymongo import ReplaceOne, UpdateOne
 from pymongo.errors import OperationFailure
 
 from dp3.common.attrspec import AttrType, timeseries_types
@@ -271,9 +271,65 @@ class EntityDatabase:
                     for eid, record in zip(eids, records)
                 ]
             )
-            self.log.debug("Updated master records of %s: %s.", eids, eids)
+            self.log.debug("Updated master records of %s: %s.", etype, eids)
         except Exception as e:
             raise DatabaseError(f"Update of master records failed: {e}\n{records}") from e
+
+    def extend_ttl(self, etype: str, eid: str, ttl_tokens: dict[str, datetime]):
+        """Extends TTL of given `etype`:`eid` by `ttl_tokens`."""
+        master_col = self._master_col_name(etype)
+        try:
+            self._db[master_col].update_one(
+                {"_id": eid},
+                {
+                    "$max": {
+                        f"#ttl.{token_name}": token_value
+                        for token_name, token_value in ttl_tokens.items()
+                    }
+                },
+            )
+            self.log.debug("Updated TTL of %s: %s.", etype, eid)
+        except Exception as e:
+            raise DatabaseError(f"TTL update failed: {e} ({ttl_tokens})") from e
+
+    def remove_expired_ttls(self, etype: str, expired_eid_ttls: dict[str, list[str]]):
+        """Removes expired TTL of given `etype`:`eid`."""
+        master_col = self._master_col_name(etype)
+        try:
+            res = self._db[master_col].bulk_write(
+                [
+                    UpdateOne(
+                        {"_id": eid},
+                        {"$unset": {f"#ttl.{token_name}": "" for token_name in expired_ttls}},
+                    )
+                    for eid, expired_ttls in expired_eid_ttls.items()
+                ]
+            )
+            self.log.debug(
+                "Removed expired TTL of %s: (%s, modified %s).",
+                etype,
+                len(expired_eid_ttls),
+                res.modified_count,
+            )
+        except Exception as e:
+            raise DatabaseError(f"TTL update failed: {e}") from e
+
+    def delete_eids(self, etype: str, eids: list[str]):
+        """Delete master record and all snapshots of `etype`:`eids`."""
+        master_col = self._master_col_name(etype)
+        snapshot_col = self._snapshots_col_name(etype)
+        try:
+            res = self._db[master_col].delete_many({"_id": {"$in": eids}})
+            self.log.debug(
+                "Deleted %s master records of %s (%s).", res.deleted_count, etype, len(eids)
+            )
+        except Exception as e:
+            raise DatabaseError(f"Delete of master record failed: {e}\n{eids}") from e
+        try:
+            res = self._db[snapshot_col].delete_many({"eid": {"$in": eids}})
+            self.log.debug("Deleted %s snapshots of %s (%s).", res.deleted_count, etype, len(eids))
+        except Exception as e:
+            raise DatabaseError(f"Delete of snapshots failed: {e}\n{eids}") from e
 
     def delete_eid(self, etype: str, eid: str):
         """Delete master record and all snapshots of `etype`:`eid`."""

--- a/dp3/snapshots/snapshooter.py
+++ b/dp3/snapshots/snapshooter.py
@@ -19,7 +19,7 @@ Module managing creation of snapshots, enabling data correlation and saving snap
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import pymongo.errors
 from pydantic import BaseModel
@@ -178,7 +178,7 @@ class SnapShooter:
 
     def register_correlation_hook(
         self,
-        hook: Callable[[str, dict], None],
+        hook: Callable[[str, dict], Union[None, list[DataPointTask]]],
         entity_type: str,
         depends_on: list[list[str]],
         may_change: list[list[str]],
@@ -193,6 +193,7 @@ class SnapShooter:
         Args:
             hook: `hook` callable should expect entity type as str
                 and its current values, including linked entities, as dict
+                Can optionally return a list of DataPointTask objects to perform.
             entity_type: specifies entity type
             depends_on: each item should specify an attribute that is depended on
                 in the form of a path from the specified entity_type to individual attributes

--- a/dp3/snapshots/snapshooter.py
+++ b/dp3/snapshots/snapshooter.py
@@ -48,6 +48,7 @@ RETRY_COUNT = 3
 
 class SnapShooterConfig(BaseModel):
     creation_rate: CronExpression = CronExpression(minute="*/30")
+    keep_empty: bool = True
 
 
 class SnapShooter:
@@ -422,6 +423,8 @@ class SnapShooter:
                     record[attr] = {k: v for k, v in value.items() if k != "record"}
 
         for rtype_rid, record in entity_values.items():
+            if len(record) == 1 and not self.config.keep_empty:
+                continue
             self.db.save_snapshot(rtype_rid[0], record, task.time)
 
     def run_timeseries_processing(self, entity_type, master_record):

--- a/dp3/snapshots/snapshot_hooks.py
+++ b/dp3/snapshots/snapshot_hooks.py
@@ -133,7 +133,7 @@ class SnapshotCorrelationHookContainer:
         self._hooks[entity_type].append((hook_id, hook))
         self._restore_hook_order(self._hooks[entity_type])
 
-        self.log.debug(f"Added hook: '{hook_id}'")
+        self.log.info(f"Added hook: '{hook_id}'")
         return hook_id
 
     def _validate_attr_paths(self, base_entity: str, paths: list[list[str]]):
@@ -261,9 +261,10 @@ class SnapshotCorrelationHookContainer:
         ]
         topological_order = self._dependency_graph.topological_order
         hook_subset.sort(key=lambda x: topological_order.index(x[0]))
-        entities_by_etype = {
-            etype_eid[0]: {etype_eid[1]: entity} for etype_eid, entity in entities.items()
-        }
+        entities_by_etype = defaultdict(dict)
+        for (etype, eid), values in entities.items():
+            entities_by_etype[etype][eid] = values
+
         created_tasks = []
 
         for hook_id, hook, etype in hook_subset:

--- a/dp3/task_processing/task_executor.py
+++ b/dp3/task_processing/task_executor.py
@@ -147,6 +147,10 @@ class TaskExecutor:
             # Run on_entity_creation hook
             new_tasks += self._task_entity_hooks[task.etype].run_on_creation(task.eid, task)
 
+        # Extend TTL
+        if task.ttl_tokens:
+            self.db.extend_ttl(task.etype, task.eid, task.ttl_tokens)
+
         # Insert into database
         try:
             self.db.insert_datapoints(task.etype, task.eid, task.data_points, new_entity=new_entity)

--- a/dp3/task_processing/task_queue.py
+++ b/dp3/task_processing/task_queue.py
@@ -542,6 +542,7 @@ class TaskQueueReader(RobustAMQPConnection):
                 self.callback(tag, task)
             except Exception as e:
                 self.log.exception("Error in user callback function. %s: %s", type(e), str(e))
+                self.log.error("Original message: %s", body)
 
     def _stop_consuming_thread(self) -> None:
         if self._consuming_thread:

--- a/dp3/task_processing/task_queue.py
+++ b/dp3/task_processing/task_queue.py
@@ -263,7 +263,8 @@ class TaskQueueWriter(RobustAMQPConnection):
         if not self.channel:
             self.connect()
 
-        self.log.debug(f"Received new broadcast task: {task}")
+        task_str = str(task) if len(str(task)) < 500 else f"{str(task)[:500]}...(truncated)"
+        self.log.debug(f"Received new broadcast task: {task_str}")
 
         body = task.as_message()
         exchange = self.exchange_pri if priority else self.exchange
@@ -283,7 +284,8 @@ class TaskQueueWriter(RobustAMQPConnection):
         if not self.channel:
             self.connect()
 
-        self.log.debug(f"Received new task: {task}")
+        task_str = str(task) if len(str(task)) < 500 else f"{str(task)[:500]}...(truncated)"
+        self.log.debug(f"Received new task: {task_str}")
 
         # Prepare routing key
         body = task.as_message()
@@ -522,7 +524,11 @@ class TaskQueueReader(RobustAMQPConnection):
             tag = msg.delivery_tag
 
             self.log.debug(
-                "Received {}message: {} (tag: {})".format("priority " if pri else "", body, tag)
+                "Received {}message: {} (tag: {})".format(
+                    "priority " if pri else "",
+                    body if len(body) < 500 else f"{body[:500]}...(truncated)",
+                    tag,
+                )
             )
 
             # Parse and check validity of received message

--- a/dp3/template/app/config/garbage_collector.yml
+++ b/dp3/template/app/config/garbage_collector.yml
@@ -1,0 +1,5 @@
+# Garbage collector configuration - cleans up expired entities
+
+# The rate at which the garbage collector will run - A CRON expression
+collection_rate:
+  minute: "5,25,45"

--- a/dp3/template/app/config/snapshots.yml
+++ b/dp3/template/app/config/snapshots.yml
@@ -4,3 +4,6 @@
 # Creating snapshots - cron schedule
 creation_rate:
   minute: "*/30"
+
+# Keep or discard empty snapshots
+keep_empty: true

--- a/dp3/worker.py
+++ b/dp3/worker.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from dp3.common.callback_registrar import CallbackRegistrar
 from dp3.common.config import PlatformConfig
 from dp3.common.control import Control, ControlAction
+from dp3.core.collector import GarbageCollector
 from dp3.history_management.telemetry import Telemetry
 from dp3.task_processing.task_queue import TaskQueueWriter
 
@@ -166,6 +167,7 @@ def main(app_name: str, config_dir: str, process_index: int, verbose: bool) -> N
 
     HistoryManager(db, platform_config, registrar)
     Telemetry(db, platform_config, registrar)
+    GarbageCollector(db, platform_config, registrar)
 
     # Lock used to control when the program stops.
     daemon_stop_lock = threading.Lock()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - General: configuration/index.md
     - Database: configuration/database.md
     - Database entities: configuration/db_entities.md
+    - Entity Lifetimes: configuration/lifetimes.md
     - Event logging: configuration/event_logging.md
     - History manager: configuration/history_manager.md
     - Modules: configuration/modules.md

--- a/tests/test_common/test_snapshots.py
+++ b/tests/test_common/test_snapshots.py
@@ -4,6 +4,7 @@ import logging
 import os
 import unittest
 from functools import partial, update_wrapper
+from typing import Callable
 
 from event_count_logger import DummyEventGroup
 
@@ -119,6 +120,11 @@ class MockDB:
                 if key in projection and projection[key]
             }
         return self.db_content[etype][eid] or {}
+
+    def register_on_entity_delete(
+        self, f_one: Callable[[str, str], None], f_many: Callable[[str, list[str]], None]
+    ):
+        ...
 
     def get_module_cache(self):
         return self.module_cache


### PR DESCRIPTION
This pull request implements two new mechanisms to handle entity lifetimes:

* **TTL tokens** (entities with specified lifetime timers)
* Reference counting (**weak entities**)

Both of these are implemented a new core module called `GarbageCollector`. There is also a third lifetime, **immortal**, which means the platform will not delete the entity by itself, just like it was before. This is the default for backwards compatibility reasons. 

The functionality has been documented in the `Entity Lifetimes` section of the configuration docs.

A new endpoint has been added to the API, which enables sending TTL tokens to specified entities and extending their lifetime.

A new internal `on delete` callback has been added to the `EntityDatabase`, so that both `GarbageCollector` and `SnapShooter` can update their link caches appropriately. HistoryManager will also recognize that an entity's lifetime has expired, and will not perform any aggregation to avoid conflicts.

While testing a bug in `SnapShooter` concerning running hooks on multiple linked entities was uncovered and fixed. 
There are also a few minor changes in logging messages, severity, and length.