### PR TITLE
Pydantic v2

### DIFF
--- a/dp3/api/internal/config.py
+++ b/dp3/api/internal/config.py
@@ -2,7 +2,7 @@ import os
 import sys
 from enum import Enum
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, ValidationError, field_validator
 
 from dp3.api.internal.dp_logger import DPLogger
 from dp3.common.config import ModelSpec, read_config_dir
@@ -20,8 +20,9 @@ class ConfigEnv(BaseModel):
     CONF_DIR: str
     ROOT_PATH: str = ""
 
-    @validator("CONF_DIR")
-    def validate(cls, v, values):
+    @field_validator("CONF_DIR")
+    @classmethod
+    def validate(cls, v):
         # Try to open config
         try:
             config = read_config_dir(v, recursive=True)

--- a/dp3/api/internal/entity_response_models.py
+++ b/dp3/api/internal/entity_response_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
-from pydantic import BaseModel, NonNegativeInt
+from pydantic import BaseModel, Field, NonNegativeInt
 
 from dp3.common.attrspec import AttrSpecType, AttrType
 
@@ -15,7 +15,7 @@ class EntityState(BaseModel):
 
     id: str
     name: str
-    attribs: dict[str, AttrSpecType]
+    attribs: dict[str, Annotated[AttrSpecType, Field(discriminator="type")]]
     eid_estimate_count: NonNegativeInt
 
 
@@ -28,7 +28,7 @@ class EntityEidList(BaseModel):
     Data does not include history of observations attributes and timeseries.
     """
 
-    time_created: Optional[datetime]
+    time_created: Optional[datetime] = None
     count: int
     total_count: int
     data: list[dict]
@@ -67,4 +67,4 @@ class EntityEidAttrValue(BaseModel):
     The value is fetched from master record.
     """
 
-    value: Any
+    value: Any = None

--- a/dp3/api/internal/helpers.py
+++ b/dp3/api/internal/helpers.py
@@ -25,4 +25,4 @@ def api_to_dp3_datapoint(api_dp_values: dict) -> DataPointBase:
     # Parse using the model
     # This may raise pydantic's ValidationError, but that's intensional (to get
     # a JSON-serializable trace as a response from API).
-    return model.parse_obj(dp3_dp_values)
+    return model.model_validate(dp3_dp_values)

--- a/dp3/api/internal/models.py
+++ b/dp3/api/internal/models.py
@@ -27,7 +27,7 @@ class DataPoint(BaseModel):
     attr: str
     v: Any
     t1: Optional[datetime] = None
-    t2: T2Datetime = Field(None, validate_default=True)
+    t2: Optional[T2Datetime] = Field(None, validate_default=True)
     c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
     src: Optional[str] = None
 

--- a/dp3/api/internal/models.py
+++ b/dp3/api/internal/models.py
@@ -25,9 +25,9 @@ class DataPoint(BaseModel):
     type: str
     id: str
     attr: str
-    v: Any = None
+    v: Any
     t1: Optional[datetime] = None
-    t2: Optional[T2Datetime] = Field(None, validate_default=True)
+    t2: T2Datetime = Field(None, validate_default=True)
     c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
     src: Optional[str] = None
 

--- a/dp3/api/internal/models.py
+++ b/dp3/api/internal/models.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from typing import Annotated, Any, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
-from pydantic_core.core_schema import FieldValidationInfo
+from pydantic import BaseModel, Field, model_validator
 
 from dp3.api.internal.helpers import api_to_dp3_datapoint
+from dp3.common.types import T2Datetime
 
 
 class DataPoint(BaseModel):
@@ -27,17 +27,9 @@ class DataPoint(BaseModel):
     attr: str
     v: Any = None
     t1: Optional[datetime] = None
-    t2: Optional[datetime] = Field(None, validate_default=True)
+    t2: Optional[T2Datetime] = Field(None, validate_default=True)
     c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
     src: Optional[str] = None
-
-    @field_validator("t2")
-    def validate_t2(cls, v, info: FieldValidationInfo):
-        t1 = info.data.get("t1") or datetime.now()
-        v = v or t1
-        if "t1" in info.data:
-            assert t1 <= v, "'t2' is before 't1'"
-        return v
 
     @model_validator(mode="after")
     def validate_against_attribute(self):

--- a/dp3/api/routers/root.py
+++ b/dp3/api/routers/root.py
@@ -35,7 +35,7 @@ async def insert_datapoints(dps: list[DataPoint], request: Request) -> SuccessRe
     """
     # Convert to DP3 datapoints
     # This should not fail as all datapoints are already validated
-    dp3_dps = [api_to_dp3_datapoint(dp.dict()) for dp in dps]
+    dp3_dps = [api_to_dp3_datapoint(dp.model_dump()) for dp in dps]
 
     # Group datapoints by etype-eid
     tasks_dps = defaultdict(list)

--- a/dp3/api/routers/root.py
+++ b/dp3/api/routers/root.py
@@ -13,7 +13,7 @@ from dp3.api.internal.entity_response_models import EntityState
 from dp3.api.internal.helpers import api_to_dp3_datapoint
 from dp3.api.internal.models import DataPoint
 from dp3.api.internal.response_models import HealthCheckResponse, SuccessResponse
-from dp3.common.task import DataPointTask
+from dp3.common.task import DataPointTask, task_context
 
 router = APIRouter()
 
@@ -45,13 +45,12 @@ async def insert_datapoints(dps: list[DataPoint], request: Request) -> SuccessRe
 
     # Create tasks
     tasks = []
-    for k in tasks_dps:
-        etype, eid = k
+    with task_context(MODEL_SPEC):
+        for k in tasks_dps:
+            etype, eid = k
 
-        # This shouldn't fail either
-        tasks.append(
-            DataPointTask(model_spec=MODEL_SPEC, etype=etype, eid=eid, data_points=tasks_dps[k])
-        )
+            # This shouldn't fail either
+            tasks.append(DataPointTask(etype=etype, eid=eid, data_points=tasks_dps[k]))
 
     # Push tasks to task queue
     for task in tasks:

--- a/dp3/bin/check.py
+++ b/dp3/bin/check.py
@@ -235,14 +235,6 @@ def main(args):
             print(stringify_source(source), "\n")
         sys.exit(1)
 
-    parsed_config.attributes["test_entity_type", "test_attr_ipv4"].dp_model.model_validate(
-        {
-            "etype": "test_entity_type",
-            "eid": "test_entity_id",
-            "attr": "test_attr_ipv4",
-            "v": "1.2.3.4",
-        }
-    )
     if args.verbose:
         # Print parsed config as JSON (print unserializable objects using str())
         print(json.dumps(parsed_config.config, indent=4, cls=ConfigEncoder))

--- a/dp3/bin/check.py
+++ b/dp3/bin/check.py
@@ -4,8 +4,6 @@ Load and check configuration from given directory, print any errors, and exit.
 TODO:
  - refactor to simplify the code, some error path matching must be done to counteract
    the AttrSpec function magic where Pydantic fails, but otherwise it is not required
- - some errors are printed to stdout, some to stderr - unify
- - integrate code into worker and api to get better errors at startup
 """
 
 import argparse
@@ -78,7 +76,7 @@ def locate_attribs_error(data: dict, sought_err: str) -> tuple[list[tuple], list
                     paths.append((attr, *err_dict["loc"]))
                     sources.append(attr_spec)
         except ValueError as exception:
-            if exception.args[0] == sought_err:
+            if sought_err.endswith(exception.args[0]):
                 paths.append((attr,))
                 sources.append(attr_spec)
 
@@ -148,8 +146,8 @@ def locate_errors(exc: ValidationError, data: dict):
     errors = []
 
     for error in exc.errors():
-        if error["loc"] == ("__root__",):
-            paths.append(("__root__",))
+        if error["loc"] == ():
+            paths.append(())
             sources.append(None)
             errors.append(error["msg"])
             continue

--- a/dp3/bin/check.py
+++ b/dp3/bin/check.py
@@ -75,7 +75,7 @@ def locate_attribs_error(data: dict, sought_err: str) -> tuple[list[tuple], list
                 if err_dict["msg"] == sought_err:
                     paths.append((attr, *err_dict["loc"]))
                     sources.append(attr_spec)
-        except ValueError as exception:
+        except (ValueError, AssertionError) as exception:
             if sought_err.endswith(exception.args[0]):
                 paths.append((attr,))
                 sources.append(attr_spec)
@@ -89,7 +89,7 @@ def locate_basemodel_error(data: list[dict], model: BaseModel) -> list[dict]:
         for item in data:
             try:
                 model(item)
-            except (ValidationError, ValueError):
+            except (ValidationError, ValueError, AssertionError):
                 locations.append(item)
     return locations
 

--- a/dp3/bin/check.py
+++ b/dp3/bin/check.py
@@ -32,7 +32,7 @@ class ConfigEncoder(JSONEncoder):
 
     def default(self, o: Any) -> Any:
         if isinstance(o, BaseModel):
-            return o.dict(exclude_none=True)
+            return o.model_dump(exclude_none=True)
         if isinstance(o, enum.Enum):
             return o.value
         if isinstance(o, datetime):
@@ -235,6 +235,14 @@ def main(args):
             print(stringify_source(source), "\n")
         sys.exit(1)
 
+    parsed_config.attributes["test_entity_type", "test_attr_ipv4"].dp_model.model_validate(
+        {
+            "etype": "test_entity_type",
+            "eid": "test_entity_id",
+            "attr": "test_attr_ipv4",
+            "v": "1.2.3.4",
+        }
+    )
     if args.verbose:
         # Print parsed config as JSON (print unserializable objects using str())
         print(json.dumps(parsed_config.config, indent=4, cls=ConfigEncoder))

--- a/dp3/common/attrspec.py
+++ b/dp3/common/attrspec.py
@@ -295,6 +295,7 @@ AttrSpecType = Union[AttrSpecTimeseries, AttrSpecObservations, AttrSpecPlain]
 def AttrSpec(id: str, spec: dict[str, Any]) -> AttrSpecType:
     """Factory for `AttrSpec` classes"""
 
+    assert isinstance(spec, dict), "Attribute specification must be a dict"
     if "type" not in spec:
         raise ValueError("Missing mandatory attribute `type`")
     attr_type = AttrType.from_str(spec.get("type"))

--- a/dp3/common/attrspec.py
+++ b/dp3/common/attrspec.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 from enum import Flag
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
     Field,
     PositiveInt,
     PrivateAttr,
-    constr,
     create_model,
-    validator,
+    field_validator,
 )
+from pydantic_core.core_schema import FieldValidationInfo
 
 from dp3.common.datapoint import (
     DataPointBase,
@@ -24,7 +24,7 @@ from dp3.common.datapoint import (
 )
 from dp3.common.datatype import DataType, ReadOnly
 from dp3.common.entityspec import SpecModel
-from dp3.common.utils import parse_time_duration
+from dp3.common.utils import parse_time_duration, time_duration_pattern
 
 # Regex of attribute and series id's
 ID_REGEX = r"^[a-zA-Z_][a-zA-Z0-9_-]*$"
@@ -74,12 +74,15 @@ class ObservationsHistoryParams(BaseModel):
 
     aggregate: bool = True
 
-    @validator("max_age", "expire_time", "pre_validity", "post_validity", pre=True)
+    @field_validator("max_age", "expire_time", "pre_validity", "post_validity", mode="before")
+    @classmethod
     def parse_time_duration(cls, v):
-        if v:
+        if v and time_duration_pattern.match(v):
             return parse_time_duration(v)
+        return v
 
-    @validator("expire_time", pre=True, always=True)
+    @field_validator("expire_time", mode="before")
+    @classmethod
     def expire_time_inf_transform(cls, v):
         return None if v == "inf" else v
 
@@ -90,10 +93,12 @@ class TimeseriesTSParams(BaseModel):
     max_age: Optional[timedelta] = None
     time_step: Optional[timedelta] = None
 
-    @validator("max_age", "time_step", pre=True)
+    @field_validator("max_age", "time_step", mode="before")
+    @classmethod
     def parse_time_duration(cls, v):
-        if v:
+        if v and time_duration_pattern.match(v):
             return parse_time_duration(v)
+        return v
 
 
 class TimeseriesSeries(BaseModel):
@@ -101,7 +106,8 @@ class TimeseriesSeries(BaseModel):
 
     data_type: DataType
 
-    @validator("data_type")
+    @field_validator("data_type")
+    @classmethod
     def check_series_data_type(cls, v):
         assert str(v) in [
             "int",
@@ -122,7 +128,7 @@ class AttrSpecGeneric(SpecModel, use_enum_values=True):
             - will be ignored if lifetime setting does not match.
     """
 
-    id: constr(regex=ID_REGEX)
+    id: str = Field(pattern=ID_REGEX)
     name: str
     description: str = ""
     ttl: Optional[timedelta] = None
@@ -133,10 +139,13 @@ class AttrSpecGeneric(SpecModel, use_enum_values=True):
     def dp_model(self) -> DataPointBase:
         return self._dp_model
 
-    @validator("ttl", pre=True)
+    @field_validator("ttl", mode="before")
+    @classmethod
     def parse_timedelta(cls, v):
         if v:
-            return parse_time_duration(v)
+            if time_duration_pattern.match(v):
+                return parse_time_duration(v)
+            return v
         else:
             return timedelta()
 
@@ -194,7 +203,7 @@ class AttrSpecClassic(AttrSpecGeneric):
 class AttrSpecPlain(AttrSpecClassic):
     """Plain attribute specification"""
 
-    t = AttrType.PLAIN
+    t: AttrType = AttrType.PLAIN
     type: Literal["plain"] = Field(..., repr=False)
 
     def __init__(self, **data):
@@ -223,7 +232,7 @@ class AttrSpecReadOnly(AttrSpecPlain):
 class AttrSpecObservations(AttrSpecClassic):
     """Observations attribute specification"""
 
-    t = AttrType.OBSERVATIONS
+    t: AttrType = AttrType.OBSERVATIONS
     type: Literal["observations"] = Field(..., repr=False)
 
     confidence: bool = False
@@ -246,11 +255,11 @@ class AttrSpecObservations(AttrSpecClassic):
 class AttrSpecTimeseries(AttrSpecGeneric):
     """Timeseries attribute specification"""
 
-    t = AttrType.TIMESERIES
+    t: AttrType = AttrType.TIMESERIES
     type: Literal["timeseries"] = Field(..., repr=False)
 
     timeseries_type: Literal["regular", "irregular", "irregular_intervals"]
-    series: dict[constr(regex=ID_REGEX), TimeseriesSeries] = {}
+    series: dict[Annotated[str, Field(pattern=ID_REGEX)], TimeseriesSeries] = {}
     timeseries_params: TimeseriesTSParams
 
     def __init__(self, **data):
@@ -284,9 +293,10 @@ class AttrSpecTimeseries(AttrSpecGeneric):
             v=(create_model(f"DataPointTimeseriesValue_{self.id}", **dp_value_typing), ...),
         )
 
-    @validator("series")
-    def add_default_series(cls, v, values):
-        ts_type = values["timeseries_type"]
+    @field_validator("series")
+    @classmethod
+    def add_default_series(cls, v, info: FieldValidationInfo):
+        ts_type = info.data["timeseries_type"]
         default_series = timeseries_types[ts_type]["default_series"]
 
         for s in default_series:

--- a/dp3/common/callback_registrar.py
+++ b/dp3/common/callback_registrar.py
@@ -24,9 +24,11 @@ def write_datapoints_into_record(model_spec: ModelSpec, tasks: list[DataPointTas
             attr_spec = model_spec.attributes[dp.etype, dp.attr]
             if attr_spec.t == AttrType.PLAIN:
                 if attr_spec.t in AttrType.PLAIN | AttrType.OBSERVATIONS and attr_spec.is_iterable:
-                    v = [elem.dict() if isinstance(elem, BaseModel) else elem for elem in dp.v]
+                    v = [
+                        elem.model_dump() if isinstance(elem, BaseModel) else elem for elem in dp.v
+                    ]
                 else:
-                    v = dp.v.dict() if isinstance(dp.v, BaseModel) else dp.v
+                    v = dp.v.model_dump() if isinstance(dp.v, BaseModel) else dp.v
 
                 record[dp.attr] = v
 
@@ -42,7 +44,7 @@ def on_entity_creation_in_snapshots(
     if not run_flag.isset():
         return []
     eid = record["eid"]
-    mock_task = DataPointTask(model_spec=model_spec, etype=etype, eid=eid, data_points=[])
+    mock_task = DataPointTask(etype=etype, eid=eid, data_points=[])
     tasks = original_hook(eid, mock_task)
     write_datapoints_into_record(model_spec, tasks, record)
     return tasks
@@ -59,7 +61,7 @@ def on_attr_change_in_snapshots(
     if not run_flag.isset():
         return []
     eid = record["eid"]
-    mock_task = DataPointTask(model_spec=model_spec, etype=etype, eid=eid, data_points=[])
+    mock_task = DataPointTask(etype=etype, eid=eid, data_points=[])
     tasks = original_hook(eid, mock_task)
     if isinstance(tasks, list):
         write_datapoints_into_record(model_spec, tasks, record)

--- a/dp3/common/config.py
+++ b/dp3/common/config.py
@@ -385,7 +385,7 @@ class PlatformConfig(BaseModel):
         process_index: Index of current process
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
 
     app_name: str
     config_base_path: str

--- a/dp3/common/datapoint.py
+++ b/dp3/common/datapoint.py
@@ -29,10 +29,10 @@ class DataPointBase(BaseModel, use_enum_values=True):
     eid: str
     attr: str
     src: Optional[str] = None
-    v: Annotated[Optional[Any], PlainSerializer(to_json_friendly, when_used="json")] = None
-    c: Optional[Any] = None
-    t1: Optional[Any] = None
-    t2: Optional[Any] = None
+    v: Annotated[Any, PlainSerializer(to_json_friendly, when_used="json")] = None
+    c: Any = None
+    t1: Any = None
+    t2: Any = None
 
 
 class DataPointPlainBase(DataPointBase):
@@ -52,7 +52,7 @@ class DataPointObservationsBase(DataPointBase):
     """
 
     t1: datetime
-    t2: Optional[T2Datetime] = None
+    t2: T2Datetime = Field(None, validate_default=True)
     c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
 
 
@@ -63,7 +63,7 @@ class DataPointTimeseriesBase(DataPointBase):
     """
 
     t1: datetime
-    t2: Optional[T2Datetime] = None
+    t2: T2Datetime = Field(None, validate_default=True)
 
 
 def is_list_ordered(to_check: list):

--- a/dp3/common/datapoint.py
+++ b/dp3/common/datapoint.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from typing import Annotated, Any, Optional, Union
 
 from pydantic import BaseModel, Field, PlainSerializer, field_validator, model_validator
-from pydantic_core.core_schema import FieldValidationInfo
+
+from dp3.common.types import T2Datetime
 
 
 def to_str(v):
@@ -48,16 +49,8 @@ class DataPointObservationsBase(DataPointBase):
     """
 
     t1: datetime
-    t2: Optional[datetime] = None
+    t2: Optional[T2Datetime] = None
     c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
-
-    @field_validator("t2")
-    @classmethod
-    def validate_t2(cls, v, info: FieldValidationInfo):
-        v = v or info.data.get("t1") or datetime.now()
-        if "t1" in info.data:
-            assert info.data["t1"] <= v, "'t2' is before 't1'"
-        return v
 
 
 class DataPointTimeseriesBase(DataPointBase):
@@ -67,14 +60,7 @@ class DataPointTimeseriesBase(DataPointBase):
     """
 
     t1: datetime
-    t2: Optional[datetime] = None
-
-    @field_validator("t2")
-    @classmethod
-    def validate_t2(cls, v, info: FieldValidationInfo):
-        if "t1" in info.data:
-            assert info.data["t1"] <= v, "'t2' is before 't1'"
-        return v
+    t2: Optional[T2Datetime] = None
 
 
 def is_list_ordered(to_check: list):

--- a/dp3/common/datapoint.py
+++ b/dp3/common/datapoint.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated, Any, Optional, Union
 
 from pydantic import BaseModel, Field, PlainSerializer
@@ -6,8 +7,10 @@ from pydantic import BaseModel, Field, PlainSerializer
 from dp3.common.types import T2Datetime
 
 
-def to_str(v):
-    return str(v)
+def to_json_friendly(v):
+    if isinstance(v, (IPv4Address, IPv6Address)):
+        return str(v)
+    return v
 
 
 class DataPointBase(BaseModel, use_enum_values=True):
@@ -26,7 +29,7 @@ class DataPointBase(BaseModel, use_enum_values=True):
     eid: str
     attr: str
     src: Optional[str] = None
-    v: Annotated[Optional[Any], PlainSerializer(to_str, when_used="json")] = None
+    v: Annotated[Optional[Any], PlainSerializer(to_json_friendly, when_used="json")] = None
     c: Optional[Any] = None
     t1: Optional[Any] = None
     t2: Optional[Any] = None

--- a/dp3/common/datapoint.py
+++ b/dp3/common/datapoint.py
@@ -1,7 +1,12 @@
 from datetime import datetime
-from typing import Optional, Union
+from typing import Annotated, Any, Optional, Union
 
-from pydantic import BaseModel, confloat, root_validator, validator
+from pydantic import BaseModel, Field, PlainSerializer, field_validator, model_validator
+from pydantic_core.core_schema import FieldValidationInfo
+
+
+def to_str(v):
+    return str(v)
 
 
 class DataPointBase(BaseModel, use_enum_values=True):
@@ -20,6 +25,10 @@ class DataPointBase(BaseModel, use_enum_values=True):
     eid: str
     attr: str
     src: Optional[str] = None
+    v: Annotated[Optional[Any], PlainSerializer(to_str, when_used="json")] = None
+    c: Optional[Any] = None
+    t1: Optional[Any] = None
+    t2: Optional[Any] = None
 
 
 class DataPointPlainBase(DataPointBase):
@@ -40,13 +49,14 @@ class DataPointObservationsBase(DataPointBase):
 
     t1: datetime
     t2: Optional[datetime] = None
-    c: confloat(ge=0.0, le=1.0) = 1.0
+    c: Annotated[float, Field(ge=0.0, le=1.0)] = 1.0
 
-    @validator("t2", always=True)
-    def validate_t2(cls, v, values):
-        v = v or values.get("t1") or datetime.now()
-        if "t1" in values:
-            assert values["t1"] <= v, "'t2' is before 't1'"
+    @field_validator("t2")
+    @classmethod
+    def validate_t2(cls, v, info: FieldValidationInfo):
+        v = v or info.data.get("t1") or datetime.now()
+        if "t1" in info.data:
+            assert info.data["t1"] <= v, "'t2' is before 't1'"
         return v
 
 
@@ -59,10 +69,11 @@ class DataPointTimeseriesBase(DataPointBase):
     t1: datetime
     t2: Optional[datetime] = None
 
-    @validator("t2")
-    def validate_t2(cls, v, values):
-        if "t1" in values:
-            assert values["t1"] <= v, "'t2' is before 't1'"
+    @field_validator("t2")
+    @classmethod
+    def validate_t2(cls, v, info: FieldValidationInfo):
+        if "t1" in info.data:
+            assert info.data["t1"] <= v, "'t2' is before 't1'"
         return v
 
 
@@ -75,8 +86,8 @@ def is_list_ordered(to_check: list):
 # They are included by child classes of `DataPointTimeseriesBase` in `AttrSpecTimeseries`,
 # where `v` is available
 # I know, this is very dirty, but there's no other way around.
-@validator("v")
-def dp_ts_v_validator(cls, v, values):
+@field_validator("v")
+def dp_ts_v_validator(v):
     # Check if all value arrays are the same length
     values_len = [len(v_i) for _, v_i in v.dict().items()]
     assert len(set(values_len)) == 1, f"Series values have different lengths: {values_len}"
@@ -85,80 +96,68 @@ def dp_ts_v_validator(cls, v, values):
 
 
 def dp_ts_root_validator_regular_wrapper(time_step):
-    def dp_ts_root_validator_regular(cls, values):
+    @model_validator(mode="after")
+    def dp_ts_root_validator_regular(self):
         """Validates or sets t2 of regular timeseries datapoint"""
-        if "v" in values and "t1" in values:
-            # Get length of first value series included in datapoint
-            first_series = list(values["v"].dict().keys())[0]
-            series_len = len(values["v"].dict()[first_series])
-            correct_t2 = values["t1"] + series_len * time_step
+        # Get length of first value series included in datapoint
+        first_series = list(self.v.dict().keys())[0]
+        series_len = len(self.v.dict()[first_series])
+        correct_t2 = self.t1 + series_len * time_step
 
-            if "t2" in values and values["t2"]:
-                assert (
-                    values["t2"] == correct_t2
-                ), "Difference of t1 and t2 is invalid. Must be values_len*time_step."
-            else:
-                values["t2"] = correct_t2
+        if self.t2:
+            assert (
+                self.t2 == correct_t2
+            ), "Difference of t1 and t2 is invalid. Must be values_len*time_step."
+        else:
+            self.t2 = correct_t2
 
-        return values
+        return self
 
-    return root_validator(dp_ts_root_validator_regular, allow_reuse=True)
+    return dp_ts_root_validator_regular
 
 
-@root_validator
-def dp_ts_root_validator_irregular(cls, values):
+@model_validator(mode="after")
+def dp_ts_root_validator_irregular(self):
     """Validates or sets t2 of irregular timeseries datapoint"""
-    if "v" in values:
-        first_time = values["v"].time[0]
-        last_time = values["v"].time[-1]
+    first_time = self.v.time[0]
+    last_time = self.v.time[-1]
 
-        # Check t1 <= first_time
-        if "t1" in values:
-            assert (
-                values["t1"] <= first_time
-            ), f"'t1' is above first item in 'time' series ({first_time})"
+    # Check t1 <= first_time
+    assert self.t1 <= first_time, f"'t1' is above first item in 'time' series ({first_time})"
 
-        # Check last_time <= t2
-        if "t2" in values and values["t2"]:
-            assert (
-                values["t2"] >= last_time
-            ), f"'t2' is below last item in 'time' series ({last_time})"
-        else:
-            values["t2"] = last_time
+    # Check last_time <= t2
+    if self.t2:
+        assert self.t2 >= last_time, f"'t2' is below last item in 'time' series ({last_time})"
+    else:
+        self.t2 = last_time
 
-        # time must be ordered
-        assert is_list_ordered(values["v"].time), "'time' series is not ordered"
+    # time must be ordered
+    assert is_list_ordered(self.v.time), "'time' series is not ordered"
 
-    return values
+    return self
 
 
-@root_validator
-def dp_ts_root_validator_irregular_intervals(cls, values):
+@model_validator(mode="after")
+def dp_ts_root_validator_irregular_intervals(self):
     """Validates or sets t2 of irregular intervals timeseries datapoint"""
-    if "v" in values:
-        first_time = values["v"].time_first[0]
-        last_time = values["v"].time_last[-1]
+    first_time = self.v.time_first[0]
+    last_time = self.v.time_last[-1]
 
-        # Check t1 <= first_time
-        if "t1" in values:
-            assert (
-                values["t1"] <= first_time
-            ), f"'t1' is above first item in 'time_first' series ({first_time})"
+    # Check t1 <= first_time
+    assert self.t1 <= first_time, f"'t1' is above first item in 'time_first' series ({first_time})"
 
-        # Check last_time <= t2
-        if "t2" in values and values["t2"]:
-            assert (
-                values["t2"] >= last_time
-            ), f"'t2' is below last item in 'time_last' series ({last_time})"
-        else:
-            values["t2"] = last_time
+    # Check last_time <= t2
+    if self.t2:
+        assert self.t2 >= last_time, f"'t2' is below last item in 'time_last' series ({last_time})"
+    else:
+        self.t2 = last_time
 
-        # Check time_first[i] <= time_last[i]
-        assert all(
-            t[0] <= t[1] for t in zip(values["v"].time_first, values["v"].time_last)
-        ), "'time_first[i] <= time_last[i]' isn't true for all 'i'"
+    # Check time_first[i] <= time_last[i]
+    assert all(
+        t[0] <= t[1] for t in zip(self.v.time_first, self.v.time_last)
+    ), "'time_first[i] <= time_last[i]' isn't true for all 'i'"
 
-    return values
+    return self
 
 
 DataPointType = Union[DataPointPlainBase, DataPointObservationsBase, DataPointTimeseriesBase]

--- a/dp3/common/datatype.py
+++ b/dp3/common/datatype.py
@@ -33,7 +33,7 @@ primitive_data_types = {
     "int64": int,
     "float": float,
     "ipv4": ipaddress.IPv4Address,
-    "ipv6": ipaddress.IPv6Network,
+    "ipv6": ipaddress.IPv6Address,
     "mac": Annotated[str, Field(pattern=r"^([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2})$")],
     "time": datetime,
     "special": Any,

--- a/dp3/common/datatype.py
+++ b/dp3/common/datatype.py
@@ -79,16 +79,6 @@ class DataType(RootModel):
     - set<str_type>
     - dict<keys>
     - category<str_type;category1,category2,...>
-
-    Attributes:
-        data_type: type for incoming value validation
-        hashable: whether contained data is hashable
-        iterable: whether the data type is iterable
-        elem_type: if `iterable`, the element data type
-        is_link: whether this data type is link
-        link_to: if `is_link` is True, what is linked target
-        mirror_link: if `is_link` is True, whether this link is mirrored
-        mirror_as: if `mirror_link` is True, what is the name of the mirrored attribute
     """
 
     root: str
@@ -107,11 +97,7 @@ class DataType(RootModel):
 
     @model_validator(mode="after")
     def determine_value_validator(self):
-        """Determines value validator (inner `data_type`)
-
-        This is not implemented inside `@validator`, because it apparently doesn't work with
-        `__root__` models.
-        """
+        """Determines value validator (inner `data_type`)."""
         str_type = self.root
 
         self._hashable = not (
@@ -216,39 +202,48 @@ class DataType(RootModel):
         return self
 
     @property
-    def data_type(self) -> str:
+    def data_type(self) -> Union[type, BaseModel]:
+        """Type for incoming value validation"""
         return self._data_type
 
     @property
     def type_info(self) -> str:
+        """String representation of the data type, immune to whitespace changes"""
         return self._type_info
 
     @property
     def hashable(self) -> bool:
+        """Whether contained data is hashable"""
         return self._hashable
 
     @property
     def iterable(self) -> bool:
+        """Whether the data type is iterable"""
         return self._iterable
 
     @property
     def elem_type(self) -> "DataType":
+        """if `iterable`, the element data type"""
         return self._elem_type
 
     @property
     def is_link(self) -> bool:
+        """Whether the data type is a link between entities"""
         return self._is_link
 
     @property
     def mirror_link(self) -> bool:
+        """If `is_link`, whether the link is mirrored"""
         return self._mirror_link
 
     @property
     def mirror_as(self) -> Union[str, None]:
+        """If `mirror_link`, what is the name of the mirrored attribute"""
         return self._mirror_as
 
     @property
     def link_to(self) -> str:
+        """If `is_link`, the target linked entity"""
         return self._link_to
 
     def get_linked_entity(self) -> str:

--- a/dp3/common/entityspec.py
+++ b/dp3/common/entityspec.py
@@ -1,9 +1,8 @@
-from datetime import timedelta
 from typing import Literal, Union
 
-from pydantic import BaseModel, Extra, Field, field_validator
+from pydantic import BaseModel, Extra, Field
 
-from dp3.common.utils import parse_time_duration
+from dp3.common.types import ParsedTimedelta
 
 
 class SpecModel(BaseModel, extra=Extra.forbid):
@@ -35,13 +34,8 @@ class TimeToLiveLifetime(SpecModel):
     """
 
     type: Literal["ttl"]
-    on_create: timedelta
+    on_create: ParsedTimedelta
     mirror_data: bool = True
-
-    @field_validator("on_create", mode="before")
-    @classmethod
-    def parse_timedelta(cls, v):
-        return parse_time_duration(v)
 
 
 class WeakLifetime(SpecModel):

--- a/dp3/common/entityspec.py
+++ b/dp3/common/entityspec.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Literal, Union
 
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, Extra, Field, field_validator
 
 from dp3.common.utils import parse_time_duration
 
@@ -38,7 +38,8 @@ class TimeToLiveLifetime(SpecModel):
     on_create: timedelta
     mirror_data: bool = True
 
-    @validator("on_create", pre=True)
+    @field_validator("on_create", mode="before")
+    @classmethod
     def parse_timedelta(cls, v):
         return parse_time_duration(v)
 

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -54,9 +54,9 @@ class Task(BaseModel, ABC):
 
 
 def instanciate_dps(v, info: FieldValidationInfo):
-    # Convert `DataPointBase` instances back to dicts
+    # If already instantiated, return
     if isinstance(v, DataPointBase):
-        v = v.model_dump()
+        return v
 
     etype = v.get("etype")
     attr = v.get("attr")

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -57,8 +57,6 @@ def instanciate_dps(v, info: FieldValidationInfo):
     # Convert `DataPointBase` instances back to dicts
     if isinstance(v, DataPointBase):
         v = v.model_dump()
-    if isinstance(v, str):
-        v = DataPointBase.model_validate(v)
 
     etype = v.get("etype")
     attr = v.get("attr")
@@ -73,7 +71,7 @@ def instanciate_dps(v, info: FieldValidationInfo):
 
     # Parse datapoint using model from attribute specification
     try:
-        return dp_model.parse_obj(v)
+        return dp_model.model_validate(v)
     except ValidationError as e:
         raise ValueError(e) from e
 

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -84,7 +84,6 @@ ValidatedDataPoint = Annotated[
     DataPointBase,
     BeforeValidator(instanciate_dps),
     AfterValidator(validate_data_points),
-    # PlainSerializer(serialize_datapoint_json, return_type=str, when_used="json"),
 ]
 
 

--- a/dp3/common/task.py
+++ b/dp3/common/task.py
@@ -76,10 +76,6 @@ def validate_data_points(v, info: FieldValidationInfo):
     return v
 
 
-def serialize_datapoint_json(dp: DataPointBase):
-    return dp.model_dump_json()
-
-
 ValidatedDataPoint = Annotated[
     DataPointBase,
     BeforeValidator(instanciate_dps),
@@ -114,7 +110,9 @@ class DataPointTask(Task):
         return f"{self.etype}:{self.eid}"
 
     def as_message(self) -> str:
-        return self.model_dump_json(exclude={"model_spec"})
+        return self.model_dump_json(
+            exclude={"model_spec"}, exclude_defaults=True, exclude_unset=True
+        )
 
     @field_validator("etype")
     def validate_etype(cls, v, info: FieldValidationInfo):
@@ -160,4 +158,4 @@ class Snapshot(Task):
         return "-".join(f"{etype}:{eid}" for etype, eid in self.entities)
 
     def as_message(self) -> str:
-        return self.json()
+        return self.model_dump_json()

--- a/dp3/common/types.py
+++ b/dp3/common/types.py
@@ -19,12 +19,17 @@ def parse_timedelta_or_passthrough(v):
 ParsedTimedelta = Annotated[timedelta, BeforeValidator(parse_timedelta_or_passthrough)]
 
 
-def validate_t2(v, info: FieldValidationInfo):
-    """t2 must be after t1, If t2 is not specified, it is set to t1."""
+def t2_implicity_t1(v, info: FieldValidationInfo):
+    """If t2 is not specified, it is set to t1."""
     v = v or info.data.get("t1")
-    if "t1" in info.data:
+    return v
+
+
+def t2_after_t1(v, info: FieldValidationInfo):
+    """t2 must be after t1"""
+    if info.data.get("t1"):
         assert info.data["t1"] <= v, "'t2' is before 't1'"
     return v
 
 
-T2Datetime = Annotated[datetime, AfterValidator(validate_t2)]
+T2Datetime = Annotated[datetime, BeforeValidator(t2_implicity_t1), AfterValidator(t2_after_t1)]

--- a/dp3/common/types.py
+++ b/dp3/common/types.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+from dp3.common.utils import parse_time_duration, time_duration_pattern
+
+
+def parse_timedelta_or_passthrough(v):
+    """
+    We pass the value to the native pydantic validator if the value does not match our pattern.
+    """
+    if v and time_duration_pattern.match(v):
+        return parse_time_duration(v)
+    return v
+
+
+ParsedTimedelta = Annotated[timedelta, BeforeValidator(parse_timedelta_or_passthrough)]

--- a/dp3/common/types.py
+++ b/dp3/common/types.py
@@ -1,7 +1,8 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Annotated
 
-from pydantic import BeforeValidator
+from pydantic import AfterValidator, BeforeValidator
+from pydantic_core.core_schema import FieldValidationInfo
 
 from dp3.common.utils import parse_time_duration, time_duration_pattern
 
@@ -16,3 +17,14 @@ def parse_timedelta_or_passthrough(v):
 
 
 ParsedTimedelta = Annotated[timedelta, BeforeValidator(parse_timedelta_or_passthrough)]
+
+
+def validate_t2(v, info: FieldValidationInfo):
+    """t2 must be after t1, If t2 is not specified, it is set to t1."""
+    v = v or info.data.get("t1")
+    if "t1" in info.data:
+        assert info.data["t1"] <= v, "'t2' is before 't1'"
+    return v
+
+
+T2Datetime = Annotated[datetime, AfterValidator(validate_t2)]

--- a/dp3/common/utils.py
+++ b/dp3/common/utils.py
@@ -55,6 +55,9 @@ def parse_rfc_time(time_str):
         raise ValueError("Wrong timestamp format")
 
 
+time_duration_pattern = re.compile(r"^\s*(\d+)([smhd])?$")
+
+
 def parse_time_duration(duration_string: Union[str, int, datetime.timedelta]) -> datetime.timedelta:
     """
     Parse duration in format <num><s/m/h/d> (or just "0").

--- a/dp3/core/collector.py
+++ b/dp3/core/collector.py
@@ -39,7 +39,7 @@ class GarbageCollector:
     ):
         self.log = logging.getLogger("GarbageCollector")
         self.model_spec = platform_config.model_spec
-        self.config = GarbageCollectorConfig.parse_obj(
+        self.config = GarbageCollectorConfig.model_validate(
             platform_config.config.get("garbage_collector", {})
         )
         self.db = db
@@ -96,7 +96,6 @@ class GarbageCollector:
     ) -> list[DataPointTask]:
         """Extends the TTL of the entity by the specified timedelta."""
         task = DataPointTask(
-            model_spec=self.model_spec,
             etype=task.etype,
             eid=eid,
             ttl_tokens={"base": datetime.utcnow() + base_ttl},
@@ -283,7 +282,6 @@ class GarbageCollector:
         """Extends the TTL of the entity by the specified timedelta."""
         now = datetime.utcnow()
         task = DataPointTask(
-            model_spec=self.model_spec,
             etype=dp.etype,
             eid=eid,
             ttl_tokens={"data": now + extend_by},
@@ -295,7 +293,6 @@ class GarbageCollector:
     ) -> list[DataPointTask]:
         """Extends the TTL of the entity by the specified timedelta."""
         task = DataPointTask(
-            model_spec=self.model_spec,
             etype=dp.etype,
             eid=eid,
             ttl_tokens={"data": dp.t2 + extend_by},
@@ -307,7 +304,6 @@ class GarbageCollector:
     ) -> list[DataPointTask]:
         """Extends the TTL of the entity by the specified timedelta."""
         task = DataPointTask(
-            model_spec=self.model_spec,
             etype=dp.etype,
             eid=eid,
             ttl_tokens={"data": dp.t2 + extend_by},

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -240,7 +240,7 @@ class EntityDatabase:
 
         # Insert raw datapoints
         raw_col = self._raw_col_name(etype)
-        dps_dicts = [dp.dict(exclude={"attr_type"}) for dp in dps]
+        dps_dicts = [dp.model_dump(exclude={"attr_type"}) for dp in dps]
         try:
             self._db[raw_col].insert_many(dps_dicts)
             self.log.debug(f"Inserted datapoints to raw collection:\n{dps}")

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Callable, Literal, Optional, Union
 
 import pymongo
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from pymongo import ReplaceOne, UpdateMany, UpdateOne
 from pymongo.errors import OperationFailure
 
@@ -55,7 +55,8 @@ class MongoConfig(BaseModel, extra="forbid"):
     password: str = "dp3"
     connection: Union[MongoStandaloneConfig, MongoReplicaConfig] = Field(..., discriminator="mode")
 
-    @validator("username", "password")
+    @field_validator("username", "password")
+    @classmethod
     def url_safety(cls, v):
         return urllib.parse.quote_plus(v)
 

--- a/dp3/history_management/history_manager.py
+++ b/dp3/history_management/history_manager.py
@@ -7,7 +7,7 @@ from json import JSONEncoder
 from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import BaseModel, Extra, validator
+from pydantic import BaseModel, Extra, field_validator
 
 from dp3.common.attrspec import (
     AttrSpecObservations,
@@ -43,7 +43,8 @@ class SnapshotCleaningConfig(BaseModel):
     schedule: CronExpression
     older_than: timedelta
 
-    @validator("older_than", pre=True)
+    @field_validator("older_than", mode="before")
+    @classmethod
     def parse_timedelta(cls, v):
         return parse_time_duration(v)
 
@@ -61,7 +62,8 @@ class DPArchivationConfig(BaseModel):
     older_than: timedelta
     archive_dir: Optional[str] = None
 
-    @validator("older_than", pre=True)
+    @field_validator("older_than", mode="before")
+    @classmethod
     def parse_timedelta(cls, v):
         return parse_time_duration(v)
 

--- a/dp3/history_management/history_manager.py
+++ b/dp3/history_management/history_manager.py
@@ -2,12 +2,12 @@ import gzip
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 from json import JSONEncoder
 from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import BaseModel, Extra, field_validator
+from pydantic import BaseModel, Extra
 
 from dp3.common.attrspec import (
     AttrSpecObservations,
@@ -17,7 +17,8 @@ from dp3.common.attrspec import (
 )
 from dp3.common.callback_registrar import CallbackRegistrar
 from dp3.common.config import CronExpression, PlatformConfig
-from dp3.common.utils import entity_expired, parse_time_duration
+from dp3.common.types import ParsedTimedelta
+from dp3.common.utils import entity_expired
 from dp3.database.database import DatabaseError, EntityDatabase
 
 DB_SEND_CHUNK = 100
@@ -41,12 +42,7 @@ class SnapshotCleaningConfig(BaseModel):
     """
 
     schedule: CronExpression
-    older_than: timedelta
-
-    @field_validator("older_than", mode="before")
-    @classmethod
-    def parse_timedelta(cls, v):
-        return parse_time_duration(v)
+    older_than: ParsedTimedelta
 
 
 class DPArchivationConfig(BaseModel):
@@ -59,13 +55,8 @@ class DPArchivationConfig(BaseModel):
     """
 
     schedule: CronExpression
-    older_than: timedelta
+    older_than: ParsedTimedelta
     archive_dir: Optional[str] = None
-
-    @field_validator("older_than", mode="before")
-    @classmethod
-    def parse_timedelta(cls, v):
-        return parse_time_duration(v)
 
 
 class HistoryManagerConfig(BaseModel, extra=Extra.forbid):

--- a/dp3/task_processing/task_distributor.py
+++ b/dp3/task_processing/task_distributor.py
@@ -1,12 +1,12 @@
-import json
 import logging
 import queue
 import threading
 import time
 from datetime import datetime
+from functools import partial
 
 from dp3.common.config import PlatformConfig
-from dp3.common.task import DataPointTask
+from dp3.common.task import DataPointTask, parse_data_point_task
 from dp3.task_processing.task_executor import TaskExecutor
 
 from ..common.callback_registrar import CallbackRegistrar
@@ -69,7 +69,7 @@ class TaskDistributor:
         # and distributes them to worker threads
         self._task_queue_reader = TaskQueueReader(
             callback=self._distribute_task,
-            parse_task=lambda body: DataPointTask(model_spec=self.model_spec, **json.loads(body)),
+            parse_task=partial(parse_data_point_task, model_spec=self.model_spec),
             app_name=platform_config.app_name,
             worker_index=self.process_index,
             rabbit_config=self.rabbit_params,

--- a/dp3/template/app/modules/test_module.py
+++ b/dp3/template/app/modules/test_module.py
@@ -1,4 +1,3 @@
-import logging
 from time import time
 
 from dp3.common.base_module import BaseModule
@@ -11,13 +10,7 @@ class TestModule(BaseModule):
     def __init__(
         self, platform_config: PlatformConfig, module_config: dict, registrar: CallbackRegistrar
     ):
-        self.log = logging.getLogger("TestModule")
-        self.log.setLevel("DEBUG")
-        self.model_spec = platform_config.model_spec
-
-        # just for testing purposes - as new value for test_attrib
-        self.counter = module_config.get("init_value", 0)
-        self.msg = module_config.get("msg", "Hello World!")
+        super().__init__(platform_config, module_config, registrar)
 
         registrar.scheduler_register(lambda: self.log.info(self.msg), second="*/10")
 
@@ -39,12 +32,16 @@ class TestModule(BaseModule):
             may_change=[["int_attr"]],
         )
 
+    def load_config(self, config: PlatformConfig, module_config: dict) -> None:
+        # just for testing purposes - as new value for test_attrib
+        self.counter = module_config.get("init_value", 0)
+        self.msg = module_config.get("msg", "Hello World!")
+
     def fill_string_attr(self, eid: str, task: DataPointTask) -> list[DataPointTask]:
         """receives eid and Task, may return new Tasks (including new DataPoints)"""
         return [
             DataPointTask(
-                model_spec=self.model_spec,
-                entity_type="example",
+                etype="example",
                 eid=eid,
                 data_points=[
                     {
@@ -67,7 +64,7 @@ class TestModule(BaseModule):
         Returns:
             new update as Task.
         """
-        print("Hello from TestModule - processing_func_timestamp")
+        self.log.info("Hello from TestModule - processing_func_timestamp")
         current_time = time()
 
         record["time_attr"] = current_time
@@ -81,7 +78,7 @@ class TestModule(BaseModule):
         Returns:
             new update as Task.
         """
-        print("Hello from TestModule - processing_func_attrib")
+        self.log.info("Hello from TestModule - processing_func_attrib")
         self.counter += 1
 
         record["test_attrib"] = self.counter

--- a/modules/test_module.py
+++ b/modules/test_module.py
@@ -1,4 +1,3 @@
-import logging
 from time import time
 
 from dp3.common.base_module import BaseModule
@@ -11,13 +10,7 @@ class TestModule(BaseModule):
     def __init__(
         self, platform_config: PlatformConfig, module_config: dict, registrar: CallbackRegistrar
     ):
-        self.log = logging.getLogger("TestModule")
-        self.log.setLevel("DEBUG")
-        self.model_spec = platform_config.model_spec
-
-        # just for testing purposes - as new value for test_attrib
-        self.counter = module_config.get("init_value", 0)
-        self.msg = module_config.get("msg", "Hello World!")
+        super().__init__(platform_config, module_config, registrar)
 
         registrar.register_entity_hook(
             "on_entity_creation", hook=self.fill_test_attr_string, entity="test_entity_type"
@@ -37,12 +30,16 @@ class TestModule(BaseModule):
             may_change=[["test_attr_int"]],
         )
 
+    def load_config(self, config: PlatformConfig, module_config: dict) -> None:
+        # just for testing purposes - as new value for test_attrib
+        self.counter = module_config.get("init_value", 0)
+        self.msg = module_config.get("msg", "Hello World!")
+
     def fill_test_attr_string(self, eid: str, task: DataPointTask) -> list[DataPointTask]:
         """receives eid and Task, may return new Tasks (including new DataPoints)"""
         return [
             DataPointTask(
-                model_spec=self.model_spec,
-                entity_type="test_entity_type",
+                etype="test_entity_type",
                 eid=eid,
                 data_points=[
                     {
@@ -65,7 +62,7 @@ class TestModule(BaseModule):
         Returns:
             new update as Task.
         """
-        print("Hello from TestModule - processing_func_timestamp")
+        self.log.info("Hello from TestModule - processing_func_timestamp")
         current_time = time()
 
         record["test_attr_time"] = current_time
@@ -79,7 +76,7 @@ class TestModule(BaseModule):
         Returns:
             new update as Task.
         """
-        print("Hello from TestModule - processing_func_attrib")
+        self.log.info("Hello from TestModule - processing_func_attrib")
         self.counter += 1
 
         record["test_attrib"] = self.counter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 AMQPStorm~=2.7.2
 apscheduler~=3.10.0
 event-count-logger>=1.1
-fastapi>=0.95.1
+fastapi>=0.100.0
 numpy>=1.23.0
 pandas~=1.4.3
-pydantic~=1.10
+pydantic>=2.1.0
 pymongo~=4.3.3
 python-dateutil~=2.8
 pyyaml>=5.3.1,<5.5.0

--- a/scripts/datapoint_log_converter.py
+++ b/scripts/datapoint_log_converter.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 
 import pandas as pd
 from dateutil.parser import parse as parsetime
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from dp3.common.config import ModelSpec, read_config_dir
 

--- a/tests/test_api/common.py
+++ b/tests/test_api/common.py
@@ -122,7 +122,7 @@ class APITest(unittest.TestCase):
     def get_entity_data(self, path: str, model: type[Model], **kwargs) -> Model:
         response = self.get_request(path, **kwargs)
         self.assertEqual(response.status_code, 200)
-        return model.parse_raw(response.content)
+        return model.model_validate_json(response.content)
 
     @staticmethod
     def get_request(path, **kwargs) -> requests.Response:

--- a/tests/test_api/test_list_entities.py
+++ b/tests/test_api/test_list_entities.py
@@ -11,5 +11,5 @@ class ListEntities(common.APITest):
         received = response.json()
         self.assertIsInstance(received, dict)
         for key, item in received.items():
-            received[key] = EntityState.parse_obj(item)
+            received[key] = EntityState.model_validate(item)
         self.assertListEqual(list(received.keys()), list(common.MODEL_SPEC.entities.keys()))

--- a/tests/test_api/test_set_attr_value.py
+++ b/tests/test_api/test_set_attr_value.py
@@ -12,7 +12,9 @@ class SetEidAttrValue(common.APITest):
 
     def test_valid_payload(self):
         payload = EntityEidAttrValue(value="Test string val1")
-        response = self.post_request(TESTED_PATH.format(action="set"), data=payload.json())
+        response = self.post_request(
+            TESTED_PATH.format(action="set"), data=payload.model_dump_json()
+        )
         self.assertEqual(response.status_code, 200)
 
         expected = EntityEidAttrValueOrHistory(attr_type=1, current_value="Test string val1")


### PR DESCRIPTION
This PR updates used Pydantic version to v2, implementing necessary adjustments.

Notable changes:
- `DataPointTask` no longer requires a `ModelSpec` instance on initialization, instead, this is passed using a `task_context` context manager. Not a breaking change yet, because running module hooks is performed with this context and the extra field is currently ignored. Should deprecate in next release.
- Moved validators closer to specified types using the new `Annotated[]` syntax. See `ParsedTimedelta`, `T2Datetime`, `ValidatedDataPoint` and types used to define `CronExpression` for examples.