### PR TITLE
Database Optimizations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,17 @@ jobs:
       - name: Setup running platform stack
         run: docker compose up --build -d
 
+      - name: Pause for stack to start
+        run: sleep 10
+
       - name: Integration tests - API
         run: docker run 
           --env CONF_DIR=/dp3/tests/test_config 
           --network container:dp3_api 
           dp3_interpreter python -m unittest discover -s tests/test_api -v
+
+      - name: Check worker errors
+        run: docker compose logs worker | grep "WARNING\|ERROR\|exception" | grep -v "RabbitMQ\|it's\ OK\ now,\ we're\ successfully\ connected" || true
 
       - name: Teardown platform stack
         run: docker compose down

--- a/config/history_manager.yml
+++ b/config/history_manager.yml
@@ -9,6 +9,10 @@ aggregation_schedule:
   minute: "*/10"
 
 # Deleting old datapoints from master records
+mark_datapoints_schedule:
+  hour: "7,19"
+  minute: "45"
+
 datapoint_cleaning_schedule:
   minute: "*/30"
 

--- a/docs/configuration/history_manager.md
+++ b/docs/configuration/history_manager.md
@@ -13,25 +13,29 @@ Configuration file `history_manager.yml` is very simple:
 aggregation_schedule:  # (1)!
   minute: "*/10"  
 
-datapoint_cleaning_schedule:  # (2)!
+mark_datapoints_schedule: # (2)!
+  hour: "7,19"
+  minute: "45"
+datapoint_cleaning_schedule:  # (3)!
   minute: "*/30"
 
 snapshot_cleaning:
-  schedule: {minute: "15,45"}  # (3)!
-  older_than: 7d  # (4)!
+  schedule: {minute: "15,45"}  # (4)!
+  older_than: 7d  # (5)!
 
 datapoint_archivation:
-  schedule: {hour: 2, minute: 0}  # (5)!
-  older_than: 7d  # (6)!
-  archive_dir: "data/datapoints/"  # (7)!
+  schedule: {hour: 2, minute: 0}  # (6)!
+  older_than: 7d  # (7)!
+  archive_dir: "data/datapoints/"  # (8)!
 ```
 
 1. Parameter `aggregation_schedule` sets the interval for DP³ to aggregate observation datapoints in master records. This should be scheduled more often than cleaning of datapoints.
-2. Parameter `datapoint_cleaning_schedule` sets interval when should DP³ check if any data in master record of observations and timeseries attributes isn't too old and if there's something too old, removes it. To control what is considered as "too old", see parameter `max_age` in *Database entities* configuration.
-3. Parameter `snapshot_cleaning.schedule` sets the interval for DP³ to clean the snapshots collection. Optimally should be scheduled outside the snapshot creation window. See *Snapshots* configuration for more.  
-4. Parameter `snapshot_cleaning.older_than` sets how old must a snapshot be to be deleted.
-5. Parameter `datapoint_archivation.schedule` sets interval for DP³ to archive datapoints from raw collections.
-6. Parameter `datapoint_archivation.older_than` sets how old must a datapoint be to be archived.
-7. Parameter `datapoint_archivation.archive_dir` sets directory where should be archived old datapoints. If directory doesn't exist, it will be created, but write priviledges must be set correctly. Can be also set to `null` (or not set) to disable archivation and only delete old data.
+2. Parameter `mark_datapoints_schedule` sets the interval when the datapoint timestamps are marked for all entities in a master collection. This should be scheduled very rarely, as it's a very expensive operation. 
+3. Parameter `datapoint_cleaning_schedule` sets interval when should DP³ check if any data in master record of observations and timeseries attributes isn't too old and if there's something too old, removes it. To control what is considered as "too old", see parameter `max_age` in *Database entities* configuration.
+4. Parameter `snapshot_cleaning.schedule` sets the interval for DP³ to clean the snapshots collection. Optimally should be scheduled outside the snapshot creation window. See *Snapshots* configuration for more.  
+5. Parameter `snapshot_cleaning.older_than` sets how old must a snapshot be to be deleted.
+6. Parameter `datapoint_archivation.schedule` sets interval for DP³ to archive datapoints from raw collections.
+7. Parameter `datapoint_archivation.older_than` sets how old must a datapoint be to be archived.
+8. Parameter `datapoint_archivation.archive_dir` sets directory where should be archived old datapoints. If directory doesn't exist, it will be created, but write priviledges must be set correctly. Can be also set to `null` (or not set) to disable archivation and only delete old data.
 
 The schedule dictionaries are transformed to cron expressions, see [CronExpression docs][dp3.common.config.CronExpression] for details.

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -61,8 +61,6 @@ def get_eid_snapshots_handler(
 ):
     """Handler for getting snapshots of EID"""
     snapshots = list(DB.get_snapshots(etype, eid, t1=date_from, t2=date_to))
-    for s in snapshots:
-        del s["_id"]
 
     return snapshots
 

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -134,11 +134,10 @@ async def list_entity_type_eids(
     time_created = None
 
     # Remove _id field
-    result = list(cursor_page)
+    result = [r["last"] for r in cursor_page]
     for r in result:
         time_created = r["_time_created"]
         del r["_time_created"]
-        del r["_id"]
 
     return EntityEidList(
         time_created=time_created, count=len(result), total_count=total_count, data=result

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -243,7 +243,7 @@ class EntityDatabase:
         """
         for etype in self._db_schema_config.entities:
             # Snapshots index on `eid` and `_time_created` fields
-            snapshot_col = self._snapshots_col_name(etype)
+            snapshot_col = self._oversized_snapshots_col_name(etype)
             self._db[snapshot_col].create_index("eid", background=True)
             self._db[snapshot_col].create_index("_time_created", background=True)
 

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -639,9 +639,11 @@ class EntityDatabase:
 
         Periodically called for all `etype`s from HistoryManager.
         """
-        master_col = self._master_col_name(etype)
+        master_col = self._db.get_collection(
+            self._master_col_name(etype), write_concern=WriteConcern(w=1)
+        )
         try:
-            return self._db[master_col].update_many(
+            return master_col.update_many(
                 {f"#min_t2s.{attr_name}": {"$lt": t_old}},
                 [
                     {

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -1227,11 +1227,12 @@ class EntityDatabase:
                 # Insert new snapshots
                 res = self._db[snapshot_col].insert_many(inserts, ordered=False)
                 new_normal.update(res.inserted_ids)
-                if len(res.inserted_ids) != len(snapshots_by_eid):
+                if len(res.inserted_ids) != len(inserts):
                     self.log.warning(
-                        "Some snapshots were not inserted, %s != %s",
+                        "Some snapshots were not inserted, %s != %s, failed: %s",
                         len(res.inserted_ids),
                         len(snapshots_by_eid),
+                        {s["_id"] for s in inserts} - set(res.inserted_ids),
                     )
             except (DocumentTooLarge, OperationFailure) as e:
                 self.log.info(f"Inserted snapshot is too large, will retry with oversize. {e}")

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -425,7 +425,7 @@ class EntityDatabase:
 
     def _push_master(self):
         """Push master changes to database."""
-        for etype, lock in self._raw_buffer_locks.items():
+        for etype, lock in self._master_buffer_locks.items():
             master_col = self._db.get_collection(
                 self._master_col_name(etype), write_concern=WriteConcern(w=1)
             )

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -774,7 +774,7 @@ class EntityDatabase:
 
         snapshot_col = self._snapshots_col_name(etype)
         return (
-            self._db[snapshot_col].find_one({"eid": eid}, {"last": 1}, sort=[("_id", -1)]) or {}
+            self._db[snapshot_col].find_one({"_id": eid}, {"last": 1}, sort=[("_id", -1)]) or {}
         ).get("last", {})
 
     def _get_latest_snapshots_date(self) -> Optional[datetime]:

--- a/dp3/history_management/history_manager.py
+++ b/dp3/history_management/history_manager.py
@@ -111,6 +111,8 @@ class HistoryManager:
         registrar.scheduler_register(
             self.delete_old_snapshots, **snapshot_cleaning_schedule.model_dump()
         )
+        self.keep_snapshot_count = self._get_snapshot_count_to_keep(platform_config.config)
+        self.log.info("Keeping %s snapshots", self.keep_snapshot_count)
 
         # Schedule datapoint archivation
         archive_config = self.config.datapoint_archivation
@@ -120,6 +122,45 @@ class HistoryManager:
         else:
             self.log_dir = None
         registrar.scheduler_register(self.archive_old_dps, **archive_config.schedule.model_dump())
+
+    def _get_snapshot_count_to_keep(self, config) -> int:
+        """Returns how many snapshots should be kept based on configuration.
+
+        This depends on the frequency of snapshot creation and the max snapshot age.
+        """
+        max_age_days = self.keep_snapshot_delta.total_seconds() / 3600 / 24
+        creation_rate = config.get("snapshots.creation_rate", {"minute": "*/30"})
+        if len(creation_rate) > 1:
+            raise ValueError("Only one snapshot creation rate is supported.")
+
+        for key, value in creation_rate.items():
+            if value.startswith("*/"):
+                snapshot_interval = int(value[2:])
+                if key == "second":
+                    snapshots_per_day = 60 * 60 * 24 / snapshot_interval
+                elif key == "minute":
+                    snapshots_per_day = 60 * 24 / snapshot_interval
+                elif key == "hour":
+                    snapshots_per_day = 24 / snapshot_interval
+                elif key == "day":
+                    snapshots_per_day = 1 / snapshot_interval
+                else:
+                    raise ValueError(f"Unsupported snapshot creation rate: {creation_rate}")
+            else:
+                count = len(value.split(","))
+                if key == "second":
+                    snapshots_per_day = 60 * 24 * count
+                elif key == "minute":
+                    snapshots_per_day = 24 * count
+                elif key == "hour":
+                    snapshots_per_day = count
+                else:
+                    raise ValueError(f"Unsupported snapshot creation rate: {creation_rate}")
+            break
+        else:
+            raise ValueError(f"Unsupported snapshot creation rate: {creation_rate}")
+
+        return int(max_age_days * snapshots_per_day)
 
     def delete_old_dps(self):
         """Deletes old data points from master collection."""
@@ -147,13 +188,14 @@ class HistoryManager:
     def delete_old_snapshots(self):
         """Deletes old snapshots."""
         t_old = datetime.now() - self.keep_snapshot_delta
-        self.log.debug("Deleting all snapshots before %s", t_old)
+        n_old = self.keep_snapshot_count
+        self.log.debug("Deleting all snapshots before %s and over %s in total", t_old, n_old)
 
         deleted_total = 0
         for etype in self.model_spec.entities:
             try:
-                result = self.db.delete_old_snapshots(etype, t_old)
-                deleted_total += result.deleted_count
+                result = self.db.delete_old_snapshots(etype, t_old, n_old)
+                deleted_total += result
             except DatabaseError as e:
                 self.log.exception(e)
         self.log.debug("Deleted %s snapshots in total.", deleted_total)

--- a/dp3/scripts/add_min_t2s.py
+++ b/dp3/scripts/add_min_t2s.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Simple script to add min_t2s to master records to allow for better indexing.
+
+Intended to be run only once to upgrade a database existing before 08-2024.
+"""
+
+import argparse
+import time
+
+from dp3.common.attrspec import AttrType
+from dp3.common.config import ModelSpec, read_config_dir
+from dp3.database.database import EntityDatabase, MongoConfig
+
+# Arguments parser
+parser = argparse.ArgumentParser(
+    description="Add min_t2s to master records to allow for better indexing."
+)
+parser.add_argument(
+    "--config",
+    default="/etc/adict/config",
+    help="DP3 config directory (default: /etc/adict/config)",
+)
+args = parser.parse_args()
+
+# Load DP3 configuration
+config = read_config_dir(args.config, recursive=True)
+model_spec = ModelSpec(config.get("db_entities"))
+
+# Connect to database
+connection_conf = MongoConfig.model_validate(config.get("database", {}))
+client = EntityDatabase.connect(connection_conf)
+client.admin.command("ping")
+
+db = client[connection_conf.db_name]
+
+
+for entity, attributes in model_spec.entity_attributes.items():
+    t1 = time.time()
+    res = db[f"{entity}#master"].update_many(
+        {},
+        [
+            {
+                "$set": {
+                    attr_name: {
+                        "$cond": {
+                            "if": {
+                                "$eq": [
+                                    {"$size": {"$ifNull": [f"${attr_name}", []]}},
+                                    0,
+                                ]
+                            },
+                            "then": "$$REMOVE",
+                            "else": f"${attr_name}",
+                        }
+                    }
+                    for attr_name, spec in attributes.items()
+                    if spec.t != AttrType.PLAIN
+                }
+                | {
+                    f"#min_t2s.{attr_name}": {
+                        "$cond": {
+                            "if": {
+                                "$eq": [
+                                    {"$size": {"$ifNull": [f"${attr_name}", []]}},
+                                    0,
+                                ]
+                            },
+                            "then": "$$REMOVE",
+                            "else": {"$min": f"${attr_name}.t2"},
+                        }
+                    }
+                    for attr_name, spec in attributes.items()
+                    if spec.t != AttrType.PLAIN
+                }
+            },
+        ],
+    )
+    t2 = time.time()
+    print(f"Updated {res.modified_count} records for entity {entity} in {t2 - t1:.2f}s")

--- a/dp3/scripts/migrate_snapshots.py
+++ b/dp3/scripts/migrate_snapshots.py
@@ -17,7 +17,8 @@ from dp3.database.database import DatabaseError, EntityDatabase, MongoConfig
 
 # Arguments parser
 parser = argparse.ArgumentParser(
-    description="Add hashes to master records to allow for easier parallelization in ADiCT."
+    description="Migrate snapshots schema from flat single-snapshot documents "
+    "to a nested history schema."
 )
 parser.add_argument(
     "--config",

--- a/dp3/scripts/migrate_snapshots.py
+++ b/dp3/scripts/migrate_snapshots.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Simple script to migrate snapshots schema from flat single-snapshot documents to
+a nested history-last schema.
+
+Intended to be run only once to upgrade a database existing before 08-2024.
+"""
+
+import argparse
+from collections import defaultdict
+
+import bson
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError, DocumentTooLarge, OperationFailure, WriteError
+
+from dp3.common.config import ModelSpec, read_config_dir
+from dp3.database.database import DatabaseError, EntityDatabase, MongoConfig
+
+# Arguments parser
+parser = argparse.ArgumentParser(
+    description="Add hashes to master records to allow for easier parallelization in ADiCT."
+)
+parser.add_argument(
+    "--config",
+    default="/etc/adict/config",
+    help="DP3 config directory (default: /etc/adict/config)",
+)
+parser.add_argument("--dry-run", action="store_true", help="Do not write to database")
+parser.add_argument("-n", default=100, type=int, help="Number of updates to send per request")
+args = parser.parse_args()
+
+# Load DP3 configuration
+config = read_config_dir(args.config, recursive=True)
+model_spec = ModelSpec(config.get("db_entities"))
+
+# Connect to database
+connection_conf = MongoConfig.model_validate(config.get("database", {}))
+client = EntityDatabase.connect(connection_conf)
+print(client)
+client.admin.command("ping")
+
+db = client[connection_conf.db_name]
+
+BSON_OBJECT_TOO_LARGE = 10334
+
+
+def _migrate_to_oversized_snapshot(etype: str, eid: str, snapshot: dict):
+    snapshot_col = f"{etype}#snapshots"
+    os_col = f"{etype}#snapshots_oversized"
+
+    if "_id" in snapshot:
+        print(f"Removing _id {snapshot['_id']} from snapshot of {eid}")
+        del snapshot["_id"]
+
+    try:
+        doc = db[snapshot_col].find_one_and_update(
+            {"_id": eid},
+            {
+                "$set": {"oversized": True, "last": snapshot, "count": 0},
+                "$unset": {"history": ""},
+            },
+        )
+        inserts = list(doc.get("history", []))
+        inserts.insert(0, doc.get("last", {}))
+        inserts.insert(0, snapshot)
+        db[os_col].insert_many(inserts)
+    except Exception as e:
+        raise DatabaseError(f"Update of snapshot {eid} failed: {e}, {snapshot}") from e
+
+
+def save_snapshot(etype: str, snapshot: dict):
+    """Saves snapshot to specified entity of current master document.
+
+    Will move snapshot to oversized snapshots if the maintained bucket is too large.
+    """
+    if "eid" not in snapshot:
+        return
+    eid = snapshot["eid"]
+
+    if "_id" in snapshot:
+        print(f"Removing _id {snapshot['_id']} from snapshot of {eid}")
+        del snapshot["_id"]
+
+    snapshot_col = f"{etype}#snapshots"
+    os_col = f"{etype}#snapshots_oversized"
+
+    # Find out if the snapshot is oversized
+    doc = db[snapshot_col].find_one({"_id": eid}, {"oversized": 1})
+    if doc is None:
+        # First snapshot of entity
+        db[snapshot_col].insert_one(
+            {"_id": eid, "last": snapshot, "history": [], "oversized": False, "count": 0}
+        )
+        print(f"Inserted snapshot of {eid}")
+        return
+    elif doc.get("oversized", False):
+        # Snapshot is already marked as oversized
+        db[snapshot_col].update_one({"_id": eid}, {"$set": {"last": snapshot}})
+        db[os_col].insert_one(snapshot)
+        return
+
+    try:
+        # Update a normal snapshot bucket
+        res = db[snapshot_col].update_one(
+            {"_id": eid},
+            [
+                {
+                    "$set": {
+                        "history": {
+                            "$concatArrays": [
+                                ["$last"],
+                                "$history",
+                            ]
+                        },
+                        "count": {"$sum": ["$count", 1]},
+                    }
+                },
+                {"$set": {"last": {"$literal": snapshot}}},
+            ],
+        )
+        if res.modified_count == 0:
+            print(f"Snapshot of {eid} was not updated, {res.raw_result}")
+    except (WriteError, OperationFailure) as e:
+        if e.code != BSON_OBJECT_TOO_LARGE:
+            raise e
+        # The snapshot is too large, move it to oversized snapshots
+        print(f"Snapshot of {eid} is too large: {e}, marking as oversized.")
+        _migrate_to_oversized_snapshot(etype, eid, snapshot)
+    except Exception as e:
+        raise DatabaseError(f"Insert of snapshot {eid} failed: {e}, {snapshot}") from e
+
+
+def save_snapshots(etype: str, snapshots: list[dict]):
+    """
+    Saves a list of snapshots of current master documents.
+
+    All snapshots must belong to same entity type.
+
+    Will move snapshots to oversized snapshots if the maintained bucket is too large.
+    For better understanding, see `save_snapshot()`.
+
+    """
+    snapshots_by_eid = defaultdict(list)
+    for snapshot in snapshots:
+        if "eid" not in snapshot:
+            continue
+        if "_id" in snapshot:
+            del snapshot["_id"]
+        snapshots_by_eid[snapshot["eid"]].append(snapshot)
+    print(f"Saving {len(snapshots)} snapshots of {len(snapshots_by_eid)} entities of {etype}")
+
+    snapshot_col = f"{etype}#snapshots"
+    os_col = f"{etype}#snapshots_oversized"
+
+    # Find out if any of the snapshots are oversized
+    docs = list(
+        db[snapshot_col].find(
+            {"_id": {"$in": list(snapshots_by_eid.keys())}}, {"oversized": 1, "eid": 1}
+        )
+    )
+
+    updates = []
+    update_originals = []
+    oversized_inserts = []
+    oversized_updates = []
+
+    for doc in docs:
+        eid = doc["_id"]
+        if not doc.get("oversized", False):
+            # A normal snapshot, shift the last snapshot to history and update last
+            updates.append(
+                UpdateOne(
+                    {"_id": eid},
+                    [
+                        {
+                            "$set": {
+                                "history": {
+                                    "$concatArrays": [
+                                        snapshots_by_eid[eid][:-1],
+                                        ["$last"],
+                                        "$history",
+                                    ]
+                                },
+                                "count": {"$sum": [len(snapshots_by_eid[eid]), "$count"]},
+                            }
+                        },
+                        {"$set": {"last": {"$literal": snapshots_by_eid[eid][-1]}}},
+                    ],
+                )
+            )
+            update_originals.append(snapshots_by_eid[eid])
+        else:
+            # Snapshot is already marked as oversized
+            oversized_inserts.extend(snapshots_by_eid[eid])
+            oversized_updates.append(
+                UpdateOne({"_id": eid}, {"$set": {"last": snapshots_by_eid[eid][-1]}})
+            )
+        del snapshots_by_eid[eid]
+
+    # The remaining snapshots are new
+    inserts = [
+        {
+            "_id": eid,
+            "last": eid_snapshots[-1],
+            "history": eid_snapshots[:-1],
+            "oversized": False,
+            "count": len(eid_snapshots) - 1,
+        }
+        for eid, eid_snapshots in snapshots_by_eid.items()
+    ]
+
+    if updates:
+        try:
+            res = db[snapshot_col].bulk_write(updates, ordered=False)
+            if res.modified_count != len(updates):
+                print(
+                    f"Some snapshots were not updated, "
+                    f"{res.modified_count} != {len(snapshots_by_eid)}"
+                )
+        except (BulkWriteError, OperationFailure) as e:
+            print("Update of snapshots failed, will retry with oversize.")
+            failed_indexes = [
+                err["index"]
+                for err in e.details["writeErrors"]
+                if err["code"] == BSON_OBJECT_TOO_LARGE
+            ]
+            failed_snapshots = (update_originals[i] for i in failed_indexes)
+            for eid_snapshots in failed_snapshots:
+                eid = eid_snapshots[0]["eid"]
+                failed_snapshots = sorted(
+                    eid_snapshots, key=lambda s: s["_time_created"], reverse=True
+                )
+                _migrate_to_oversized_snapshot(etype, eid, failed_snapshots[0])
+                oversized_inserts.extend(failed_snapshots[1:])
+
+            if any(err["code"] != BSON_OBJECT_TOO_LARGE for err in e.details["writeErrors"]):
+                # Some other error occurred
+                raise e
+        except Exception as e:
+            raise DatabaseError(f"Update of snapshots failed: {str(e)[:2048]}") from e
+
+    if inserts:
+        try:
+            # Insert new snapshots
+            res = db[snapshot_col].insert_many(inserts, ordered=False)
+            if len(res.inserted_ids) != len(snapshots_by_eid):
+                print(
+                    f"Some snapshots were not inserted, "
+                    f"{len(res.inserted_ids)} != {len(snapshots_by_eid)}"
+                )
+        except (DocumentTooLarge, OperationFailure) as e:
+            print(f"Snapshot too large: {e}")
+            checked_inserts = []
+            oversized_inserts = []
+
+            # Filter out the oversized snapshots
+            for insert_doc in inserts:
+                bsize = len(bson.BSON.encode(insert_doc))
+                if bsize < 16 * 1024 * 1024:
+                    checked_inserts.append(insert_doc)
+                else:
+                    eid = insert_doc["_id"]
+                    checked_inserts.append(
+                        {
+                            "_id": eid,
+                            "last": insert_doc["last"],
+                            "oversized": True,
+                            "history": [],
+                            "count": 0,
+                        }
+                    )
+                    oversized_inserts.extend(insert_doc["history"] + [insert_doc["last"]])
+            try:
+                db[snapshot_col].insert_many(checked_inserts, ordered=False)
+            except Exception as e:
+                raise DatabaseError(f"Insert of snapshots failed: {e}") from e
+        except Exception as e:
+            raise DatabaseError(f"Insert of snapshot failed: {e}") from e
+
+    # Update the oversized snapshots
+    if oversized_inserts:
+        try:
+            if oversized_updates:
+                db[snapshot_col].bulk_write(oversized_updates)
+            db[os_col].insert_many(oversized_inserts)
+        except Exception as e:
+            raise DatabaseError(f"Insert of snapshots failed: {str(e)[:2048]}") from e
+
+
+for entity in model_spec.entities:
+    if len(list(db.list_collections(filter={"name": f"{entity}#snapshots_old"}))) == 0:
+        db[f"{entity}#snapshots"].rename(f"{entity}#snapshots_old")
+    print(entity)
+
+    snapshots = []
+    for record in db[f"{entity}#snapshots_old"].find({}, sort=[("_time_created", 1)]):
+        del record["_id"]
+        snapshots.append(record)
+        if len(snapshots) >= args.n:
+            if not args.dry_run:
+                save_snapshots(entity, snapshots)
+            else:
+                print(f"Would save {len(snapshots)} snapshots")
+            snapshots.clear()
+    if snapshots and not args.dry_run:
+        save_snapshots(entity, snapshots)
+    elif snapshots:
+        print(f"Would save {len(snapshots)} snapshots")

--- a/dp3/template/app/config/history_manager.yml
+++ b/dp3/template/app/config/history_manager.yml
@@ -9,6 +9,10 @@ aggregation_schedule:
   minute: "*/10"
 
 # Deleting old datapoints from master records
+mark_datapoints_schedule:
+  hour: "7,19"
+  minute: "45"
+
 datapoint_cleaning_schedule:
   minute: "*/30"
 

--- a/tests/test_api/test_get_attr_value.py
+++ b/tests/test_api/test_get_attr_value.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import common
 from common import ACCEPTED_ERROR_CODES
 
@@ -13,6 +15,11 @@ TESTED_INT_PATH = TESTED_PATH.format(
 
 
 class GetEidAttrValue(common.APITest):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        sleep(10)
+
     def test_unknown_entity_type(self):
         response = self.get_request(
             TESTED_PATH.format(entity="xyz", eid="test_entity_id", attr="test_attr_int")

--- a/tests/test_api/test_get_distinct_attr_values.py
+++ b/tests/test_api/test_get_distinct_attr_values.py
@@ -34,10 +34,11 @@ class GetDistinctAttrValues(APITest):
                 ]
             )
             print(res.content.decode("utf-8"), file=sys.stderr)
+        sleep(9)
 
         # Make snapshots
         cls.get_request("control/make_snapshots")
-        sleep(3)
+        sleep(6)
 
     def test_unknown_entity_type(self):
         response = self.get_request(TESTED_PATH.format(entity="xyz", attr="test_attr_int"))

--- a/tests/test_api/test_get_entity_eids.py
+++ b/tests/test_api/test_get_entity_eids.py
@@ -17,8 +17,9 @@ class GetEntityEids(common.APITest):
                 [{**dp_base, "id": f"A{i}", "v": f"v{i}"} for i in range(i, i + 20)]
             )
             print(res.content.decode("utf-8"), file=sys.stderr)
+        sleep(8)
         cls.get_request("control/make_snapshots")
-        sleep(3)
+        sleep(6)
 
     def test_get_entity_eids(self):
         eids = self.get_entity_data("entity/A", EntityEidList)
@@ -30,7 +31,7 @@ class GetEntityEids(common.APITest):
 
         for i in range(0, 100, 10):
             eids = self.get_entity_data("entity/A", EntityEidList, skip=i, limit=10)
-            self.assertEqual(10, len(eids.data))
+            self.assertEqual(10, len(eids.data), f"Failed at {i}")
             received_eids.update(x["eid"] for x in eids.data)
 
         eids = self.get_entity_data("entity/A", EntityEidList, skip=101, limit=20)
@@ -39,7 +40,7 @@ class GetEntityEids(common.APITest):
 
     def test_get_entity_eids_generic_filter(self):
         eids = self.get_entity_data(
-            "entity/A", EntityEidList, generic_filter=json.dumps({"eid": "A0"})
+            "entity/A", EntityEidList, generic_filter=json.dumps({"_id": "A0"})
         )
         self.assertEqual(1, len(eids.data))
         self.assertEqual("A0", eids.data[0]["eid"])

--- a/tests/test_config/history_manager.yml
+++ b/tests/test_config/history_manager.yml
@@ -9,6 +9,10 @@ aggregation_schedule:
   minute: "*/10"
 
 # Deleting old datapoints from master records
+mark_datapoints_schedule:
+  hour: "7,19"
+  minute: "45"
+
 datapoint_cleaning_schedule:
   minute: "*/30"
 

--- a/tests/test_example/config/history_manager.yml
+++ b/tests/test_example/config/history_manager.yml
@@ -9,6 +9,10 @@ aggregation_schedule:
   minute: "*/10"
 
 # Deleting old datapoints from master records
+mark_datapoints_schedule:
+  hour: "7,19"
+  minute: "45"
+
 datapoint_cleaning_schedule:
   minute: "*/30"
 


### PR DESCRIPTION
Reworked schema for the `snapshots` collections and operations with index of `master` collections. This allowed for better performance while also reducing the index size to a fraction of the previously used ones.

This introduces a breaking change to the database. To migrate, see the added `migrate_snapshots.py` and `add_min_t2s.py` scripts. (or delete the current snapshots collection and wait for the t2s to accumulate) 

HistoryManager has a new periodic procedure that has to be configured. To migrate, add the following to the configuration:

```yaml
mark_datapoints_schedule:
  hour: "7,19"
  minute: "45"
```