### PR TITLE
DB: fix unpacking of fulltext filters in `for` loop

### DIFF
--- a/dp3/database/snapshots.py
+++ b/dp3/database/snapshots.py
@@ -246,7 +246,7 @@ class TypedSnapshotCollection(abc.ABC):
         query["latest"] = True
 
         # Process fulltext filters
-        for attr, attr_filter in fulltext_filters:
+        for attr, attr_filter in fulltext_filters.items():
             fulltext_filter = {"$regex": attr_filter, "$options": "i"}
 
             # EID filter


### PR DESCRIPTION
Fixes error:
```
...
File ".../dp3/database/snapshots.py", line 249, in _prepare_latest_query
    for attr, attr_filter in fulltext_filters:
ValueError: too many values to unpack (expected 2)
```
thrown at `GET /entity/{etype}/get` and `GET /entity/{etype}/count` endpoints when `fulltext_filters` are not empty.

Most likely just a missed replacement from d8ae2b4.