### PR TITLE
Add `dp3 sh` CLI interface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup running platform stack
-        run: docker compose up --build -d
-
       - name: Integration tests - API
-        run: docker run
-          --env CONF_DIR=/dp3/tests/test_config
-          --network container:dp3_api
-          dp3_interpreter python -m unittest discover -s tests/test_api -v
+        run: bash ./scripts/run_api_tests_local.sh
 
       - name: Teardown platform stack
-        run: docker compose down
+        if: always()
+        run: docker compose down -v --remove-orphans
 
   unit-tests:
     needs: [black, ruff]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,27 +12,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup running platform stack
-        run: docker compose up --build -d
-
-      - name: Pause for stack to start
-        run: sleep 10
-
       - name: Integration tests - API
-        run: docker run 
-          --env CONF_DIR=/dp3/tests/test_config 
-          --network container:dp3_api 
-          dp3_interpreter python -m unittest discover -s tests/test_api -v
+        run: bash ./scripts/run_api_tests_local.sh
 
       - name: Dump Logs on Failure
         if: failure()
         run: docker compose logs
 
       - name: Check worker errors
+        if: always()
         run: docker compose logs worker | grep "WARNING\|ERROR\|exception" | grep -v "RabbitMQ\|it's\ OK\ now,\ we're\ successfully\ connected" || true
 
       - name: Teardown platform stack
-        run: docker compose down
+        if: always()
+        run: docker compose down -v --remove-orphans
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -96,15 +96,12 @@ docker compose -f docker-compose.app.yml up -d --build
 
 Either way, to test that everything is running properly, you can run:
 ```shell
-curl -X 'GET' 'http://localhost:5000/' \
-     -H 'Accept: application/json' 
+dp3 sh health
 ```
 
 Which should return a JSON response with the following content:
 ```json
-{
-   "detail": "It works!"
-}
+{"detail": "It works!"}
 ```
 
 Final note, to simplify the experience of adjusting the app configuration, 
@@ -155,16 +152,14 @@ The `docker-compose.yml` configuration contains the configuration for the servic
 as well as a testing setup of the DP³ platform itself. 
 The full configuration is in `tests/test_config`.
 The setup includes one worker process and one API process to handle requests. 
-The API process is exposed on port 5000, so you can send requests to it using `curl` or from your browser:
+The API process is exposed on port 5000, so you can send requests to it using `curl`, from your browser, or using the `dp3 sh` CLI:
 
 ```shell
-curl -X 'GET' 'http://localhost:5000/' \
-     -H 'Accept: application/json' 
+dp3 sh health
 ```
 ```shell
-curl -X 'POST' 'http://localhost:5000/datapoints' \
-     -H 'Content-Type: application/json' \
-     --data '[{"type": "test_entity_type", "id": "abc", "attr": "test_attr_int", "v": 123, "t1": "2023-07-01T12:00:00", "t2": "2023-07-01T13:00:00"}]'
+echo '[{"type": "test_entity_type", "id": "abc", "attr": "test_attr_int", "v": 123, "t1": "2023-07-01T12:00:00", "t2": "2023-07-01T13:00:00"}]\n' \
+  | dp3 sh datapoints
 ```
 
 ### Testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   rabbitmq:
-    container_name: "rabbitmq"
     image: "dp3_rabbitmq"
     build: "docker/rabbitmq"
     ports:
@@ -19,14 +18,12 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: test
 
   redis:
-    container_name: "redis"
     image: redis
     ports:
       - "6379:6379"
     command: [ "redis-server", "--appendonly", "yes" ]
 
   receiver_api:
-    container_name: "dp3_api"
     image: "dp3_interpreter"
     build:
       context: .
@@ -42,7 +39,6 @@ services:
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000" ]
 
   worker:
-    container_name: "dp3_worker"
     image: "dp3_interpreter"
     build:
       context: .

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install --upgrade pip; \
     pip install -r requirements.txt
 
 COPY . /dp3/
-RUN pip install -e /dp3
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 pip install -e /dp3

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,8 @@ As the API is made using FastAPI, there is also an interactive documentation ava
 
 If you are wiring a new producer into a DP³ application, start with [How to add an input module](howto/add-input.md), then use this page as the endpoint reference.
 
+For routine same-host reads and writes, prefer `dp3 sh` or the generated `<APPNAME>sh` wrapper. They provide a shell-oriented interface for the common API workflows documented here. Use raw HTTP requests when you need to exercise the underlying endpoint behavior directly.
+
 There are several API endpoints:
 
 - [`GET /`](#index): check if API is running (just returns `It works!` message)

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,15 +11,22 @@ There are several API endpoints:
 - [`POST /datapoints`](#insert-datapoints): insert datapoints into DP³
 - [`GET /entity/<entity_type>/get`](#get-entities): get current snapshots of entities of entity type
 - [`GET /entity/<entity_type>/count`](#count-entities): get total document count for query of entity type
-- [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of entity with given entity id
+- [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of the entity identified by type and id
+- [`GET /entity/<entity_type>/<entity_id>/master`](#get-master-record): get the master record of the entity identified by type and id
+- [`GET /entity/<entity_type>/<entity_id>/snapshots`](#get-snapshots): get snapshot history of the entity identified by type and id, optionally with `skip` and `limit`
 - [`GET /entity/<entity_type>/<entity_id>/get/<attr_id>`](#get-attr-value): get attribute value
-- [`GET /entity/<entity_type>/<entity_id>/set/<attr_id>`](#set-attr-value): set attribute value
+- [`POST /entity/<entity_type>/<entity_id>/set/<attr_id>`](#set-attr-value): set attribute value
 - [`GET /entity/<entity_type>/_/distinct/<attr_id>`](#get-distinct-values): get distinct attribute values and their counts based on latest snapshots
 - [`DELETE /entity/<entity_type>/<entity_id>`](#delete-eid-data): delete entity data for given id
 - [`POST /entity/<entity_type>/<entity_id>/ttl`](#extend-ttls): extend TTLs of the specified entity
 - [`GET /entities`](#entities): list entity configuration
 - [`GET /control/<action>`](#control): send a pre-defined action into execution queue.
-- [`GET /telemetry/sources_validity`](#telemetry): get information about the validity of the data sources
+- [`GET /telemetry/sources_validity`](#source-validity): get timestamps of latest data from each source
+- [`GET /telemetry/sources_age`](#source-age): get source ages in seconds or minutes
+- [`GET /telemetry/entities_per_attr`](#entities-per-attribute): get entity counts for each configured attribute
+- [`GET /telemetry/snapshot_summary`](#snapshot-summary): get summary of recent snapshot activity
+- [`GET /telemetry/metadata`](#metadata): browse metadata records stored in `#metadata`
+- [`GET /telemetry/rabbitmq/queues`](#rabbitmq-queues): get RabbitMQ queue telemetry for the running application
 
 ---
 
@@ -225,7 +232,7 @@ Generic and fulltext filters are merged - fulltext overrides conflicting keys.
 
 ### Request
 
-`GET /entity/<entity_type>`
+`GET /entity/<entity_type>/get`
 
 **Optional query parameters:**
 
@@ -239,6 +246,7 @@ Generic and fulltext filters are merged - fulltext overrides conflicting keys.
 ```json
 {
   "time_created": "2023-07-04T12:10:38.827Z",
+  "count": 1,
   "data": [
     {}
   ]
@@ -274,7 +282,7 @@ See [`GET /entity/<entity_type>/get`](#get-entities) for details on filter forma
 
 ## Get Eid data
 
-Get data of entity type's eid.
+Get data of the entity identified by `entity_type` and `entity_id`.
 
 Contains all snapshots and master record. Snapshots are ordered by ascending creation time.
 
@@ -301,8 +309,60 @@ Contains all snapshots and master record. Snapshots are ordered by ascending cre
 
 ---
 
-## Get attr value
+## Get master record
 
+Get the master record of the entity identified by `entity_type` and `entity_id`.
+
+### Request
+
+`GET /entity/<entity_type>/<entity_id>/master`
+
+**Optional query parameters:**
+
+- date_from: date-time string
+- date_to: date-time string
+
+### Response
+
+```json
+{
+  "attr1": "value",
+  "attr2": []
+}
+```
+
+---
+
+## Get snapshots
+
+Get snapshot history of the entity identified by `entity_type` and `entity_id`.
+
+This endpoint returns matching snapshots ordered by ascending creation time.
+By default, all matching snapshots are returned. Optional `skip` and `limit` parameters can be used
+for paged access without changing the response shape.
+
+### Request
+
+`GET /entity/<entity_type>/<entity_id>/snapshots`
+
+**Optional query parameters:**
+
+- date_from: date-time string
+- date_to: date-time string
+- skip: how many snapshots to skip (default: 0)
+- limit: how many snapshots to return (`0` means no limit)
+
+### Response
+
+```json
+[
+  {}
+]
+```
+
+---
+
+## Get attr value
 
 Get attribute value
 
@@ -490,7 +550,10 @@ You can learn more about the actions in the [Actions](configuration/control.md#a
   "detail": "OK"
 }
 ```
-## Telemetry
+
+---
+
+## Source validity
 
 Returns information about the validity of the data sources, i.e. when the last datapoint was received from each source.
 
@@ -504,7 +567,144 @@ Returns information about the validity of the data sources, i.e. when the last d
 {
   "module1@collector1": "2023-10-03T11:59:58.063000",
   "module2@collector1": "2023-12-06T09:09:37.165000",
-  "module3@collector2": "2023-12-08T15:52:55.282000",
-  ...
+  "module3@collector2": "2023-12-08T15:52:55.282000"
+}
+```
+
+---
+
+## Source age
+
+Returns age of the latest datapoint from each source.
+
+### Request
+
+`GET /telemetry/sources_age`
+
+**Optional query parameters:**
+
+- unit: `minutes` or `seconds` (default: `minutes`)
+
+### Response
+
+```json
+{
+  "module1@collector1": 15,
+  "module2@collector1": 42
+}
+```
+
+---
+
+## Entities per attribute
+
+Returns counts of entities for which each configured attribute currently has data present.
+
+### Request
+
+`GET /telemetry/entities_per_attr`
+
+### Response
+
+```json
+{
+  "ip": {
+    "open_ports": 1245,
+    "tags": 1198
+  },
+  "device": {
+    "risk_score": 421
+  }
+}
+```
+
+---
+
+## Snapshot summary
+
+Returns a summary of recent snapshot activity based on metadata stored by `SnapShooter`.
+
+### Request
+
+`GET /telemetry/snapshot_summary`
+
+### Response
+
+```json
+{
+  "latest_age": 73.2,
+  "finished_age": 1873.5,
+  "entities": 123456,
+  "total_s": 18.4
+}
+```
+
+Fields may be `null` when the corresponding snapshot run has not been observed yet.
+
+---
+
+## Metadata
+
+Browse records from the internal `#metadata` collection.
+
+This endpoint is useful for operational inspection of metadata written by modules such as
+`SnapShooter`, `HistoryManager`, and other components using `db.save_metadata` / `db.update_metadata`.
+
+### Request
+
+`GET /telemetry/metadata`
+
+**Optional query parameters:**
+
+- module: filter by metadata module name
+- date_from: date-time string
+- date_to: date-time string
+- skip: how many metadata records to skip (default: 0)
+- limit: how many metadata records to return (`0` means no limit)
+- sort: `newest` or `oldest` (default: `newest`)
+
+### Response
+
+```json
+[
+  {
+    "#module": "SnapShooter",
+    "#worker": 0,
+    "#time_created": "2026-04-22T08:11:10.000Z"
+  }
+]
+```
+
+---
+
+## RabbitMQ queues
+
+Returns RabbitMQ queue telemetry for the running application.
+
+The API derives RabbitMQ connection details from the configured message broker settings.
+Only queues belonging to the current DP³ application are returned.
+
+### Request
+
+`GET /telemetry/rabbitmq/queues`
+
+### Response
+
+```json
+{
+  "queues": [
+    {
+      "name": "my_app-worker-0",
+      "queue": "0-main",
+      "total": 0,
+      "ready": 0,
+      "unacked": 0,
+      "consumers": 1,
+      "memory": 12345,
+      "message_bytes": 0,
+      "incoming": 0.0,
+      "outgoing": 0.0
+    }
+  ]
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,6 @@ There are several API endpoints:
 
 - [`GET /`](#index): check if API is running (just returns `It works!` message)
 - [`POST /datapoints`](#insert-datapoints): insert datapoints into DP³
-- ~~[`GET /entity/<entity_type>`](#list-entities): list current snapshots of all entities of given type~~
 - [`GET /entity/<entity_type>/get`](#get-entities): get current snapshots of entities of entity type
 - [`GET /entity/<entity_type>/count`](#count-entities): get total document count for query of entity type
 - [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of entity with given entity id
@@ -196,44 +195,6 @@ Returns some validation error message, for example:
 1 validation error for DataPointObservations_some_field
 v -> some_embedded_dict_field
   field required (type=value_error.missing)
-```
-
----
-
-## List entities
-
-!!! warning "Deprecated"
-
-    This endpoint is deprecated and will be removed in the future, 
-    Use [`GET /entity/<entity_type>/get`](#get-entities) to get paged documents and
-    [`GET /entity/<entity_type>/count`](#count-entities) to get total document count for query.
-
-List latest snapshots of all ids present in database under entity type, 
-filtered by `generic_filter` and `fulltext_filters`.
-Contains only the latest snapshot per entity. 
-
-Counts all results for given query.
-
-### Request
-
-`GET /entity/<entity_type>`
-
-**Optional query parameters:**
-
-- skip: how many entities to skip (default: 0)
-- limit: how many entities to return (default: 20)
-- fulltext_filters: dictionary of fulltext filters (default: no filters)
-- generic_filter: dictionary of generic filters (default: no filters)
-
-### Response
-
-```json
-{
-  "time_created": "2023-07-04T12:10:38.827Z",
-  "data": [
-    {}
-  ]
-}
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@ There are several API endpoints:
 - [`POST /datapoints`](#insert-datapoints): insert datapoints into DP³
 - [`GET /entity/<entity_type>/get`](#get-entities): get current snapshots of entities of entity type
 - [`GET /entity/<entity_type>/count`](#count-entities): get total document count for query of entity type
+- [`GET /entity/<entity_type>/raw/get`](#get-raw-datapoints): get raw datapoints from the current raw collection for troubleshooting
 - [`GET /entity/<entity_type>/<entity_id>`](#get-eid-data): get data of the entity identified by type and id
 - [`GET /entity/<entity_type>/<entity_id>/master`](#get-master-record): get the master record of the entity identified by type and id
 - [`GET /entity/<entity_type>/<entity_id>/snapshots`](#get-snapshots): get snapshot history of the entity identified by type and id, optionally with `skip` and `limit`
@@ -275,6 +276,52 @@ See [`GET /entity/<entity_type>/get`](#get-entities) for details on filter forma
 ```json
 {
   "total_count": 0
+}
+```
+
+---
+
+## Get raw datapoints
+
+Browse the current raw datapoints stored in `{entity_type}#raw`.
+
+This endpoint is intended for troubleshooting ingestion. It exposes the raw datapoints received by DP³,
+before you inspect the derived master record or snapshots. It can be slow on large raw collections,
+so prefer narrow filters and small limits.
+
+Filtering is intentionally narrow: use `attr`, `eid`, and `limit` to inspect a small recent slice.
+When `attr` refers to an observations or timeseries attribute, matching datapoints are returned in
+newest-first order by `t1`. For plain attributes, the database's natural order is used.
+
+### Request
+
+`GET /entity/<entity_type>/raw/get`
+
+**Optional query parameters:**
+
+- eid: entity id to match exactly
+- attr: attribute id to match exactly
+- src: datapoint source string to match exactly
+- skip: how many datapoints to skip (default: 0)
+- limit: how many datapoints to return (default: 20, `0` means no limit)
+
+### Response
+
+```json
+{
+  "count": 2,
+  "data": [
+    {
+      "type": "device",
+      "id": "device-123",
+      "attr": "risk_score",
+      "v": 0.82,
+      "src": "manual_test",
+      "t1": null,
+      "t2": null,
+      "c": null
+    }
+  ]
 }
 ```
 

--- a/docs/howto/add-attribute.md
+++ b/docs/howto/add-attribute.md
@@ -241,7 +241,7 @@ you need direct database access.
     dp3 sh entity device list \
       --has-attr risk_score \
       --limit 5 \
-      | jq -r '.data[].eid'
+      | jq -r '.eid'
     ```
 
     Then inspect the attribute directly on a specific entity:

--- a/docs/howto/add-attribute.md
+++ b/docs/howto/add-attribute.md
@@ -199,13 +199,13 @@ you need direct database access.
     Then inspect the attribute directly on a specific entity:
 
     ```shell
-    dp3 sh entity device device-123 attr risk_score get
+    dp3 sh entity device id device-123 attr risk_score get
     ```
 
     Or inspect the full master record in context:
 
     ```shell
-    dp3 sh entity device device-123 master
+    dp3 sh entity device id device-123 master
     ```
 
 === "MongoDB (`mongosh`)"

--- a/docs/howto/add-attribute.md
+++ b/docs/howto/add-attribute.md
@@ -162,56 +162,96 @@ If the attribute still does not appear where you expect it, use the checks below
 
 For secondary DP³ modules, worker logs are often the first place where callback failures or type mismatches become visible.
 
-### Check MongoDB directly
+### Inspect raw ingestion and stored state
 
-Use direct database inspection when API-level checks are not enough, especially when debugging raw ingestion or module-produced datapoints.
+When API-level checks are not enough, inspect the raw datapoints first and then follow up with
+entity-level reads. The CLI path below is preferred for common troubleshooting. Raw inspection can
+be slow on large collections, so keep the query narrow. Keep the `mongosh` flow as a fallback when
+you need direct database access.
 
-```shell
-mongosh "mongodb://<user>:<password>@<host>:<port>/"
-```
+=== "CLI (`dp3 sh`)"
 
-```javascript
-use <db_name>
-entity = "device";
-attr = "risk_score";
+    Check whether datapoints for the attribute reached current raw storage:
 
-// `#raw` contains incoming datapoints.
-db.getCollection(`${entity}#raw`).findOne({attr: attr})
-db.getCollection(`${entity}#raw`).find({attr: attr}).sort({t1: -1}).limit(5)
+    ```shell
+    dp3 sh --config /path/to/config entity raw device \
+      --attr risk_score \
+      --limit 5 \
+      --format ndjson
+    ```
 
-// `#master` contains the current stored state.
-// Plain attribute
-// db.getCollection(`${entity}#master`).find({[attr]: {$exists: true}}).limit(5)
+    If you need entity ids that currently have stored data for the attribute, list a few latest
+    snapshots and extract their ids:
 
-// Observations attribute
-// db.getCollection(`${entity}#master`).find({$and: [{[attr]: {$exists: true}}, {[attr]: {$ne: []}}]}).limit(5)
-```
+    ```shell
+    dp3 sh --config /path/to/config entity list device \
+      --has-attr risk_score \
+      --limit 5 \
+      | jq -r '.data[].eid'
+    ```
 
-To print only the stored value of a plain attribute:
+    Then inspect the attribute directly on a specific entity:
 
-```javascript
-(db
-  .getCollection(`${entity}#master`)
-  .find({[attr]: {$exists: true}})
-  .limit(5)
-  .forEach((x) => print(x[attr]["v"]))
-)
-```
+    ```shell
+    dp3 sh --config /path/to/config entity attr \
+      device device-123 risk_score
+    ```
 
-To print compact observation history:
+    Or inspect the full master record in context:
 
-```javascript
-(db
-  .getCollection(`${entity}#master`)
-  .find({$and: [{[attr]: {$exists: true}}, {[attr]: {$ne: []}}]})
-  .limit(5)
-  .forEach((y) => {
-    print(y["_id"]);
-    y[attr].forEach((z) => print(z["t1"], z["t2"], z["v"]));
-    print();
-  })
-)
-```
+    ```shell
+    dp3 sh --config /path/to/config entity master \
+      device device-123
+    ```
+
+=== "MongoDB (`mongosh`)"
+
+    ```shell
+    mongosh "mongodb://<user>:<password>@<host>:<port>/"
+    ```
+
+    ```javascript
+    use <db_name>
+    entity = "device";
+    attr = "risk_score";
+
+    // `#raw` contains incoming datapoints.
+    db.getCollection(`${entity}#raw`).findOne({attr: attr})
+    db.getCollection(`${entity}#raw`).find({attr: attr}).sort({t1: -1}).limit(5)
+
+    // `#master` contains the current stored state.
+    // Plain attribute
+    // db.getCollection(`${entity}#master`).find({[attr]: {$exists: true}}).limit(5)
+
+    // Observations attribute
+    // db.getCollection(`${entity}#master`).find({$and: [{[attr]: {$exists: true}}, {[attr]: {$ne: []}}]}).limit(5)
+    ```
+
+    To print only the stored value of a plain attribute:
+
+    ```javascript
+    (db
+      .getCollection(`${entity}#master`)
+      .find({[attr]: {$exists: true}})
+      .limit(5)
+      .forEach((x) => print(x[attr]["v"]))
+    )
+    ```
+
+    To print compact observation history:
+
+    ```javascript
+    (db
+      .getCollection(`${entity}#master`)
+      .find({$and: [{[attr]: {$exists: true}}, {[attr]: {$ne: []}}]})
+      .limit(5)
+      .forEach((y) => {
+        print(y["_id"]);
+        y[attr].forEach((z) => print(z["t1"], z["t2"], z["v"]));
+        print();
+      })
+    )
+    ```
 
 ## Common failure modes
 

--- a/docs/howto/add-attribute.md
+++ b/docs/howto/add-attribute.md
@@ -171,10 +171,16 @@ you need direct database access.
 
 === "CLI (`dp3 sh`)"
 
+    Set the config directory once for the session:
+
+    ```shell
+    export DP3_CONFIG_DIR=/path/to/config
+    ```
+
     Check whether datapoints for the attribute reached current raw storage:
 
     ```shell
-    dp3 sh --config /path/to/config entity raw device \
+    dp3 sh entity device raw \
       --attr risk_score \
       --limit 5 \
       --format ndjson
@@ -184,7 +190,7 @@ you need direct database access.
     snapshots and extract their ids:
 
     ```shell
-    dp3 sh --config /path/to/config entity list device \
+    dp3 sh entity device list \
       --has-attr risk_score \
       --limit 5 \
       | jq -r '.data[].eid'
@@ -193,15 +199,13 @@ you need direct database access.
     Then inspect the attribute directly on a specific entity:
 
     ```shell
-    dp3 sh --config /path/to/config entity attr \
-      device device-123 risk_score
+    dp3 sh entity device device-123 attr risk_score get
     ```
 
     Or inspect the full master record in context:
 
     ```shell
-    dp3 sh --config /path/to/config entity master \
-      device device-123
+    dp3 sh entity device device-123 master
     ```
 
 === "MongoDB (`mongosh`)"

--- a/docs/howto/add-attribute.md
+++ b/docs/howto/add-attribute.md
@@ -81,56 +81,104 @@ Once the configuration is live, enable the producer that emits the new attribute
 - For an external producer or primary input module, start sending datapoints to the DP³ API.
 - For a secondary DP³ module, restart the worker if needed, then trigger the callback path that emits the datapoint.
 
-A quick way to prove the configuration works independently of your real producer is to submit one test datapoint manually. Using the `risk_score` example above:
+A quick way to prove the configuration works independently of your real producer is to submit one test datapoint manually. Using the `risk_score` example above, prefer `dp3 sh` for routine same-host checks and keep `curl` as a fallback when you need to work with the raw HTTP request.
 
-```shell
-curl -X POST 'http://localhost:5000/datapoints' \
-  -H 'Content-Type: application/json' \
-  --data '[
-    {
-      "type": "device",
-      "id": "device-123",
-      "attr": "risk_score",
-      "v": 0.82,
-      "t1": "2026-04-21T12:00:00Z",
-      "t2": "2026-04-21T12:05:00Z",
-      "src": "manual_test"
-    }
-  ]'
-```
+=== "CLI (`dp3 sh`)"
+
+    Set the config directory once for the session:
+
+    ```shell
+    export DP3_CONFIG_DIR=/path/to/config
+    ```
+
+    Then submit one test datapoint:
+
+    ```shell
+    printf '%s\n' '[
+      {
+        "type": "device",
+        "id": "device-123",
+        "attr": "risk_score",
+        "v": 0.82,
+        "t1": "2026-04-21T12:00:00Z",
+        "t2": "2026-04-21T12:05:00Z",
+        "src": "manual_test"
+      }
+    ]' | dp3 sh datapoints
+    ```
+
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X POST 'http://localhost:5000/datapoints' \
+      -H 'Content-Type: application/json' \
+      --data '[
+        {
+          "type": "device",
+          "id": "device-123",
+          "attr": "risk_score",
+          "v": 0.82,
+          "t1": "2026-04-21T12:00:00Z",
+          "t2": "2026-04-21T12:05:00Z",
+          "src": "manual_test"
+        }
+      ]'
+    ```
 
 Adjust the URL, entity type, entity id, attribute id, and payload to match your application.
 
 ## 5. Verify through the API
 
-Prefer API-level verification first.
+Prefer API-level verification first. For routine checks on the same host, prefer `dp3 sh` and keep `curl` as a fallback.
 
-Start by reading the attribute directly:
+=== "CLI (`dp3 sh`)"
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/get/risk_score' \
-  -H 'Accept: application/json'
-```
+    Start by reading the attribute directly:
 
-What you should expect depends on the attribute type:
+    ```shell
+    dp3 sh entity device id device-123 attr risk_score get
+    ```
 
-- `plain` attributes return the current value.
-- `observations` attributes return the current value together with history.
-- `timeseries` attributes return history samples.
+    What you should expect depends on the attribute type:
 
-Then inspect the full master record if you want to see the attribute in context:
+    - `plain` attributes return the current value.
+    - `observations` attributes return the current value together with history.
+    - `timeseries` attributes return history samples.
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/master' \
-  -H 'Accept: application/json'
-```
+    Then inspect the full master record if you want to see the attribute in context:
 
-If snapshots are enabled for the entity type, you can also check the snapshot view after a snapshot run:
+    ```shell
+    dp3 sh entity device id device-123 master
+    ```
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/snapshots' \
-  -H 'Accept: application/json'
-```
+    If snapshots are enabled for the entity type, you can also check the snapshot view after a snapshot run:
+
+    ```shell
+    dp3 sh entity device id device-123 snapshots
+    ```
+
+=== "HTTP (`curl`)"
+
+    Start by reading the attribute directly:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/get/risk_score' \
+      -H 'Accept: application/json'
+    ```
+
+    Then inspect the full master record if you want to see the attribute in context:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/master' \
+      -H 'Accept: application/json'
+    ```
+
+    If snapshots are enabled for the entity type, you can also check the snapshot view after a snapshot run:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/snapshots' \
+      -H 'Accept: application/json'
+    ```
 
 ## 6. Deeper checks and troubleshooting
 

--- a/docs/howto/add-input.md
+++ b/docs/howto/add-input.md
@@ -23,12 +23,28 @@ If the input only sends datapoints for attributes that already exist, you can co
 
 ## 2. Confirm that the API is reachable
 
-A new input module should be tested against a running DP³ API before you debug the producer itself.
+A new input module should be tested against a running DP³ API before you debug the producer itself. For routine same-host checks, prefer `dp3 sh` and keep `curl` as a fallback.
 
-```shell
-curl -X GET 'http://localhost:5000/' \
-  -H 'Accept: application/json'
-```
+=== "CLI (`dp3 sh`)"
+
+    Set the config directory once for the session:
+
+    ```shell
+    export DP3_CONFIG_DIR=/path/to/config
+    ```
+
+    Then run the health check:
+
+    ```shell
+    dp3 sh health
+    ```
+
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X GET 'http://localhost:5000/' \
+      -H 'Accept: application/json'
+    ```
 
 A healthy API responds with:
 
@@ -73,21 +89,39 @@ Before running the real input module, send one datapoint manually. This narrows 
 - DP³ configuration and API handling, or
 - the input module implementation itself
 
-```shell
-curl -X POST 'http://localhost:5000/datapoints' \
-  -H 'Content-Type: application/json' \
-  --data '[
-    {
-      "type": "device",
-      "id": "device-123",
-      "attr": "risk_score",
-      "v": 0.82,
-      "t1": "2026-04-21T12:00:00Z",
-      "t2": "2026-04-21T12:05:00Z",
-      "src": "manual_test"
-    }
-  ]'
-```
+=== "CLI (`dp3 sh`)"
+
+    ```shell
+    printf '%s\n' '[
+      {
+        "type": "device",
+        "id": "device-123",
+        "attr": "risk_score",
+        "v": 0.82,
+        "t1": "2026-04-21T12:00:00Z",
+        "t2": "2026-04-21T12:05:00Z",
+        "src": "manual_test"
+      }
+    ]' | dp3 sh datapoints
+    ```
+
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X POST 'http://localhost:5000/datapoints' \
+      -H 'Content-Type: application/json' \
+      --data '[
+        {
+          "type": "device",
+          "id": "device-123",
+          "attr": "risk_score",
+          "v": 0.82,
+          "t1": "2026-04-21T12:00:00Z",
+          "t2": "2026-04-21T12:05:00Z",
+          "src": "manual_test"
+        }
+      ]'
+    ```
 
 Once the manual request works, point your input module at the same API endpoint and send the same shape of payload.
 
@@ -106,21 +140,37 @@ It is worth keeping one datapoint field stable during testing, especially `src`,
 
 ## 6. Verify that data is flowing through DP³
 
-Start with API-level verification.
+Start with API-level verification. For routine checks on the same host, prefer `dp3 sh` and keep `curl` as a fallback.
 
-To read one attribute directly:
+=== "CLI (`dp3 sh`)"
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/get/risk_score' \
-  -H 'Accept: application/json'
-```
+    To read one attribute directly:
 
-To inspect the full master record for the entity:
+    ```shell
+    dp3 sh entity device id device-123 attr risk_score get
+    ```
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/master' \
-  -H 'Accept: application/json'
-```
+    To inspect the full master record for the entity:
+
+    ```shell
+    dp3 sh entity device id device-123 master
+    ```
+
+=== "HTTP (`curl`)"
+
+    To read one attribute directly:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/get/risk_score' \
+      -H 'Accept: application/json'
+    ```
+
+    To inspect the full master record for the entity:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/master' \
+      -H 'Accept: application/json'
+    ```
 
 If the attribute shows up for the manually sent datapoint but not for the real input module, the remaining problem is in the producer, not in the DP³ model.
 

--- a/docs/howto/add-input.md
+++ b/docs/howto/add-input.md
@@ -165,7 +165,8 @@ slow on large collections, and keep the `mongosh` flow as a fallback.
 === "CLI (`dp3 sh`)"
 
     ```shell
-    dp3 sh --config /path/to/config entity raw device \
+    export DP3_CONFIG_DIR=/path/to/config
+    dp3 sh entity device raw \
       --attr risk_score \
       --limit 5 \
       --format ndjson
@@ -175,7 +176,7 @@ slow on large collections, and keep the `mongosh` flow as a fallback.
     data for the attribute and extract their ids:
 
     ```shell
-    dp3 sh --config /path/to/config entity list device \
+    dp3 sh entity device list \
       --has-attr risk_score \
       --limit 5 \
       | jq -r '.data[].eid'

--- a/docs/howto/add-input.md
+++ b/docs/howto/add-input.md
@@ -229,7 +229,7 @@ slow on large collections, and keep the `mongosh` flow as a fallback.
     dp3 sh entity device list \
       --has-attr risk_score \
       --limit 5 \
-      | jq -r '.data[].eid'
+      | jq -r '.eid'
     ```
 
 === "MongoDB (`mongosh`)"

--- a/docs/howto/add-input.md
+++ b/docs/howto/add-input.md
@@ -156,19 +156,43 @@ If the request succeeds but the data still does not appear as expected, inspect 
     tail -f /var/log/<APPNAME>/worker0.log
     ```
 
-### Check MongoDB directly when needed
+### Inspect raw ingestion when needed
 
-If you need to distinguish between ingestion and later processing, check whether the datapoint reached raw storage:
+If you need to distinguish between ingestion and later processing, inspect current raw datapoints first.
+Prefer the CLI path for common troubleshooting, keep the query narrow because raw inspection can be
+slow on large collections, and keep the `mongosh` flow as a fallback.
 
-```javascript
-use <db_name>
-entity = "device";
-attr = "risk_score";
+=== "CLI (`dp3 sh`)"
 
-db.getCollection(`${entity}#raw`).find({attr: attr}).sort({t1: -1}).limit(5)
-```
+    ```shell
+    dp3 sh --config /path/to/config entity raw device \
+      --attr risk_score \
+      --limit 5 \
+      --format ndjson
+    ```
 
-If the datapoint is present in `#raw` but not visible where you expect it later, inspect the model, worker logs, and attribute definition again.
+    If you need candidate entity ids for follow-up checks, list entities whose latest snapshot has
+    data for the attribute and extract their ids:
+
+    ```shell
+    dp3 sh --config /path/to/config entity list device \
+      --has-attr risk_score \
+      --limit 5 \
+      | jq -r '.data[].eid'
+    ```
+
+=== "MongoDB (`mongosh`)"
+
+    ```javascript
+    use <db_name>
+    entity = "device";
+    attr = "risk_score";
+
+    db.getCollection(`${entity}#raw`).find({attr: attr}).sort({t1: -1}).limit(5)
+    ```
+
+If the datapoint is present in `#raw` but not visible where you expect it later, inspect the model,
+worker logs, and attribute definition again.
 
 ## Common failure modes
 

--- a/docs/howto/add-module.md
+++ b/docs/howto/add-module.md
@@ -135,28 +135,60 @@ If you also changed `db_entities` because the module emits a new attribute, relo
 
 Now trigger the event that should make the module run.
 
-For the example above, send or replay a datapoint for the `device.hostname` attribute. A manual test through the API is often the fastest way to confirm the module is wired correctly:
+For the example above, send or replay a datapoint for the `device.hostname` attribute. For routine same-host checks, prefer `dp3 sh` and keep `curl` as a fallback.
 
-```shell
-curl -X POST 'http://localhost:5000/datapoints' \
-  -H 'Content-Type: application/json' \
-  --data '[
-    {
-      "type": "device",
-      "id": "device-123",
-      "attr": "hostname",
-      "v": "Example.Host",
-      "src": "manual_test"
-    }
-  ]'
-```
+=== "CLI (`dp3 sh`)"
 
-If the module emits `hostname_normalized`, verify it through the API:
+    Set the config directory once for the session:
 
-```shell
-curl -X GET 'http://localhost:5000/entity/device/device-123/get/hostname_normalized' \
-  -H 'Accept: application/json'
-```
+    ```shell
+    export DP3_CONFIG_DIR=/path/to/config
+    ```
+
+    A manual test datapoint is often the fastest way to confirm the module is wired correctly:
+
+    ```shell
+    printf '%s\n' '[
+      {
+        "type": "device",
+        "id": "device-123",
+        "attr": "hostname",
+        "v": "Example.Host",
+        "src": "manual_test"
+      }
+    ]' | dp3 sh datapoints
+    ```
+
+    If the module emits `hostname_normalized`, verify it directly:
+
+    ```shell
+    dp3 sh entity device id device-123 attr hostname_normalized get
+    ```
+
+=== "HTTP (`curl`)"
+
+    A manual test datapoint is often the fastest way to confirm the module is wired correctly:
+
+    ```shell
+    curl -X POST 'http://localhost:5000/datapoints' \
+      -H 'Content-Type: application/json' \
+      --data '[
+        {
+          "type": "device",
+          "id": "device-123",
+          "attr": "hostname",
+          "v": "Example.Host",
+          "src": "manual_test"
+        }
+      ]'
+    ```
+
+    If the module emits `hostname_normalized`, verify it through the API:
+
+    ```shell
+    curl -X GET 'http://localhost:5000/entity/device/device-123/get/hostname_normalized' \
+      -H 'Accept: application/json'
+    ```
 
 ## 7. Check logs and troubleshoot
 

--- a/docs/howto/deploy-app.md
+++ b/docs/howto/deploy-app.md
@@ -260,12 +260,20 @@ Start with process status:
 <APPNAME>ctl status
 ```
 
-Then verify the API health endpoint:
+Then verify the API health endpoint. On the deployment host, prefer the generated `<APPNAME>sh` wrapper and keep `curl` as a fallback.
 
-```shell
-curl -X GET 'http://<HOSTNAME>/' \
-  -H 'Accept: application/json'
-```
+=== "CLI (`<APPNAME>sh`)"
+
+    ```shell
+    <APPNAME>sh health
+    ```
+
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X GET 'http://<HOSTNAME>/' \
+      -H 'Accept: application/json'
+    ```
 
 A healthy API responds with:
 

--- a/docs/howto/deploy-app.md
+++ b/docs/howto/deploy-app.md
@@ -333,7 +333,7 @@ Use the API to confirm that the deployment still answers health and data request
 - `GET /` for health
 - `/docs` for interactive endpoint reference
 - `dp3 sh entities | jq keys` to list the configured entity type names exposed by the running app (`dp3 sh entities` returns the full entity-type configuration map)
-- `dp3 sh entity <ETYPE> <EID> master` or `dp3 sh entity <ETYPE> <EID> attr <ATTR> get` for spot checks against real data
+- `dp3 sh entity <ETYPE> id <EID> master` or `dp3 sh entity <ETYPE> id <EID> attr <ATTR> get` for spot checks against real data
 
 When you are working directly on the deployment host, prefer `<APPNAME>sh ...` because it already knows the production config directory.
 

--- a/docs/howto/deploy-app.md
+++ b/docs/howto/deploy-app.md
@@ -217,12 +217,19 @@ sudo systemctl enable <APP_NAME>
 sudo systemctl start <APP_NAME>
 ```
 
-This creates an `<APPNAME>ctl` helper that wraps `supervisorctl` for the app:
+This creates two app-specific helpers:
+
+- `<APPNAME>ctl` wraps `supervisorctl` for the app
+- `<APPNAME>sh` wraps `dp3 sh` with the app config directory already set
 
 ```shell
 <APPNAME>ctl start all
 <APPNAME>ctl status
+<APPNAME>sh health
+<APPNAME>sh entities | jq keys
 ```
+
+`<APPNAME>sh entities` returns the full entity-type configuration map exposed by the API. When you only need the configured entity type names, pipe it through `jq keys`.
 
 The generated supervisor configuration lives under `/etc/<APP_NAME>` and the process logs are written under `/var/log/<APP_NAME>`.
 For more on supervisor itself, see the [supervisorctl documentation](http://supervisord.org/running.html#running-supervisorctl).
@@ -307,7 +314,10 @@ Use the API to confirm that the deployment still answers health and data request
 
 - `GET /` for health
 - `/docs` for interactive endpoint reference
-- entity or attribute endpoints for spot checks against real data
+- `dp3 sh entities | jq keys` to list the configured entity type names exposed by the running app (`dp3 sh entities` returns the full entity-type configuration map)
+- `dp3 sh entity <ETYPE> <EID> master` or `dp3 sh entity <ETYPE> <EID> attr <ATTR> get` for spot checks against real data
+
+When you are working directly on the deployment host, prefer `<APPNAME>sh ...` because it already knows the production config directory.
 
 ### RabbitMQ management
 

--- a/docs/howto/deploy-app.md
+++ b/docs/howto/deploy-app.md
@@ -210,6 +210,9 @@ Generate the base supervisor configuration for the app:
 sudo $(which dp3) config supervisor --config <CONFIG_DIR> --app-name <APP_NAME>
 ```
 
+The generated supervisor configuration lives under `/etc/<APP_NAME>` and the process logs are written under `/var/log/<APP_NAME>`.
+For more on supervisor itself, see the [supervisorctl documentation](http://supervisord.org/running.html#running-supervisorctl).
+
 Enable and start the generated system service:
 
 ```shell
@@ -231,26 +234,66 @@ This creates two app-specific helpers:
 
 `<APPNAME>sh entities` returns the full entity-type configuration map exposed by the API. When you only need the configured entity type names, pipe it through `jq keys`.
 
-You can also enable shell completion for the wrapper or for `dp3 sh` itself:
+You can also enable shell completion for the wrapper or for `dp3` itself.
+The completion is registered for the executable name seen by the shell:
 
-```shell
-# Bash
-source <(<APPNAME>sh completion bash --command <APPNAME>sh)
-source <(dp3 sh completion bash --command dp3)
+- use `--command dp3` for the main `dp3` command tree
+- use `--command <APPNAME>sh` for the generated wrapper
 
-# Zsh
-source <(<APPNAME>sh completion zsh --command <APPNAME>sh)
-source <(dp3 sh completion zsh --command dp3)
+#### Session-local autocomplete 
 
-# Fish
-<APPNAME>sh completion fish --command <APPNAME>sh | source
-dp3 sh completion fish --command dp3 | source
-```
+Enable completion in the current shell session only:
+
+=== "Bash"
+
+    ```shell
+    source <(dp3 sh completion bash --command dp3 --command <APPNAME>sh)
+    ```
+
+=== "Zsh"
+
+    ```shell
+    source <(dp3 sh completion zsh --command dp3 --command <APPNAME>sh)
+    ```
+
+=== "Fish"
+
+    ```shell
+    dp3 sh completion fish --command dp3 --command <APPNAME>sh | source
+    ```
+
+#### Persistent activation
+
+To keep completion enabled across shell sessions, add the appropriate command to your shell startup file.
+
+=== "Bash"
+
+    Add one of these to `~/.bashrc`:
+
+    ```shell
+    source <(<APPNAME>sh completion bash --command <APPNAME>sh)
+    source <(dp3 sh completion bash --command dp3)
+    ```
+
+=== "Zsh"
+
+    Add one of these to `~/.zshrc`:
+
+    ```shell
+    source <(<APPNAME>sh completion zsh --command <APPNAME>sh)
+    source <(dp3 sh completion zsh --command dp3)
+    ```
+
+=== "Fish"
+
+    Write the generated completion to a Fish completion file:
+
+    ```shell
+    <APPNAME>sh completion fish --command <APPNAME>sh > ~/.config/fish/completions/<APPNAME>sh.fish
+    dp3 sh completion fish --command dp3 > ~/.config/fish/completions/dp3.fish
+    ```
 
 The generated completion is config-aware. It can suggest entity types and attribute names from the resolved DP3 configuration.
-
-The generated supervisor configuration lives under `/etc/<APP_NAME>` and the process logs are written under `/var/log/<APP_NAME>`.
-For more on supervisor itself, see the [supervisorctl documentation](http://supervisord.org/running.html#running-supervisorctl).
 
 ### 6. Check that the deployment is healthy
 

--- a/docs/howto/deploy-app.md
+++ b/docs/howto/deploy-app.md
@@ -231,6 +231,24 @@ This creates two app-specific helpers:
 
 `<APPNAME>sh entities` returns the full entity-type configuration map exposed by the API. When you only need the configured entity type names, pipe it through `jq keys`.
 
+You can also enable shell completion for the wrapper or for `dp3 sh` itself:
+
+```shell
+# Bash
+source <(<APPNAME>sh completion bash --command <APPNAME>sh)
+source <(dp3 sh completion bash --command dp3)
+
+# Zsh
+source <(<APPNAME>sh completion zsh --command <APPNAME>sh)
+source <(dp3 sh completion zsh --command dp3)
+
+# Fish
+<APPNAME>sh completion fish --command <APPNAME>sh | source
+dp3 sh completion fish --command dp3 | source
+```
+
+The generated completion is config-aware. It can suggest entity types and attribute names from the resolved DP3 configuration.
+
 The generated supervisor configuration lives under `/etc/<APP_NAME>` and the process logs are written under `/var/log/<APP_NAME>`.
 For more on supervisor itself, see the [supervisorctl documentation](http://supervisord.org/running.html#running-supervisorctl).
 

--- a/docs/howto/develop-dp3.md
+++ b/docs/howto/develop-dp3.md
@@ -91,28 +91,43 @@ The repository's compose setup uses `tests/test_config` as the application confi
 
 ## 4. Confirm that the test platform is running
 
-Check the API health endpoint:
+Check the API health endpoint. For routine same-host checks, prefer `dp3 sh` and keep `curl` as a fallback.
 
-```shell
-curl -X GET 'http://localhost:5000/' \
-  -H 'Accept: application/json'
-```
+=== "CLI (`dp3 sh`)"
 
-A healthy API responds with:
+    ```shell
+    export DP3_CONFIG_DIR=tests/test_config
+    dp3 sh health
+    ```
 
-```json
-{
-  "detail": "It works!"
-}
-```
+    You can also send a sample datapoint through the running test API:
 
-You can also send a sample datapoint through the running test API:
+    ```shell
+    printf '%s\n' '[{"type": "test_entity_type", "id": "abc", "attr": "test_attr_int", "v": 123, "t1": "2023-07-01T12:00:00", "t2": "2023-07-01T13:00:00"}]' | dp3 sh datapoints
+    ```
 
-```shell
-curl -X POST 'http://localhost:5000/datapoints' \
-  -H 'Content-Type: application/json' \
-  --data '[{"type": "test_entity_type", "id": "abc", "attr": "test_attr_int", "v": 123, "t1": "2023-07-01T12:00:00", "t2": "2023-07-01T13:00:00"}]'
-```
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X GET 'http://localhost:5000/' \
+      -H 'Accept: application/json'
+    ```
+
+    A healthy API responds with:
+
+    ```json
+    {
+      "detail": "It works!"
+    }
+    ```
+
+    You can also send a sample datapoint through the running test API:
+
+    ```shell
+    curl -X POST 'http://localhost:5000/datapoints' \
+      -H 'Content-Type: application/json' \
+      --data '[{"type": "test_entity_type", "id": "abc", "attr": "test_attr_int", "v": 123, "t1": "2023-07-01T12:00:00", "t2": "2023-07-01T13:00:00"}]'
+    ```
 
 ## 5. Run tests as you work
 

--- a/docs/howto/get-started.md
+++ b/docs/howto/get-started.md
@@ -246,6 +246,62 @@ A healthy API responds with:
 
 At this point, you have a local DP³ environment ready for trying configuration changes and testing new code.
 
+### Optional: enable shell completion for `dp3`
+
+By default, the following will generate completion for the `dp3` executable.
+
+#### Session-local activation
+
+Enable completion in the current shell session only:
+
+=== "Bash"
+
+    ```shell
+    source <(dp3 sh completion bash)
+    ```
+
+=== "Zsh"
+
+    ```shell
+    source <(dp3 sh completion zsh)
+    ```
+
+=== "Fish"
+
+    ```shell
+    dp3 sh completion fish | source
+    ```
+
+#### Persistent activation
+
+To keep completion enabled across shell sessions, add the appropriate command to your shell startup file.
+
+=== "Bash"
+
+    Add this to `~/.bashrc`:
+
+    ```shell
+    source <(dp3 sh completion bash)
+    ```
+
+=== "Zsh"
+
+    Add this to `~/.zshrc`:
+
+    ```shell
+    source <(dp3 sh completion zsh)
+    ```
+
+=== "Fish"
+
+    Write the generated completion to a Fish completion file:
+
+    ```shell
+    dp3 sh completion fish > ~/.config/fish/completions/dp3.fish
+    ```
+
+The generated completion is config-aware. It can suggest entity types and attribute names from the resolved DP3 configuration.
+
 ## 7. Sanity-check configuration changes as you iterate
 
 When you change configuration, especially `config/db_entities`, validate it before restarting services:

--- a/docs/howto/get-started.md
+++ b/docs/howto/get-started.md
@@ -220,12 +220,21 @@ For module and configuration development, the local-shell option is often easier
 
 ## 6. Confirm that the local app is working
 
-Run a simple API health check:
+Run a simple API health check. For routine same-host checks, prefer `dp3 sh` and keep `curl` as a fallback.
 
-```shell
-curl -X GET 'http://localhost:5000/' \
-  -H 'Accept: application/json'
-```
+=== "CLI (`dp3 sh`)"
+
+    ```shell
+    export DP3_CONFIG_DIR=config
+    dp3 sh health
+    ```
+
+=== "HTTP (`curl`)"
+
+    ```shell
+    curl -X GET 'http://localhost:5000/' \
+      -H 'Accept: application/json'
+    ```
 
 A healthy API responds with:
 

--- a/dp3/api/internal/config.py
+++ b/dp3/api/internal/config.py
@@ -81,4 +81,9 @@ CONTROL_WRITER = TaskQueueWriter(
 )
 DP_LOGGER = DPLogger(CONFIG.get("api.datapoint_logger"))
 ROOT_PATH = conf_env.ROOT_PATH
-TELEMETRY_READER = TelemetryReader(DB)
+TELEMETRY_READER = TelemetryReader(
+    DB,
+    conf_env.APP_NAME,
+    CONFIG.get("processing_core.worker_processes"),
+    CONFIG.get("processing_core.msg_broker"),
+)

--- a/dp3/api/internal/entity_response_models.py
+++ b/dp3/api/internal/entity_response_models.py
@@ -38,17 +38,15 @@ EntityEidSnapshots = list[SnapshotType]
 
 
 class EntityEidList(BaseModel):
-    """List of entity eids and their data based on latest snapshot
+    """List of entity eids and their data based on latest snapshot.
 
-    Includes timestamp of latest snapshot creation, count of returned documents
-    and total count of documents available under specified filter.
+    Includes timestamp of latest snapshot creation and count of returned documents.
 
     Data does not include history of observations attributes and timeseries.
     """
 
     time_created: Optional[datetime] = None
     count: int
-    total_count: int
     data: EntityEidSnapshots
 
 

--- a/dp3/api/internal/entity_response_models.py
+++ b/dp3/api/internal/entity_response_models.py
@@ -56,6 +56,16 @@ class EntityEidCount(BaseModel):
     total_count: int
 
 
+RawDataPoint = dict[str, Any]
+
+
+class EntityRawDataPage(BaseModel):
+    """Page of raw datapoints for troubleshooting raw ingestion."""
+
+    count: int
+    data: list[RawDataPoint]
+
+
 class EntityEidData(BaseModel):
     """Data of entity eid
 

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -98,46 +98,6 @@ def _validate_snapshot_filters(fulltext_filters, generic_filter):
 
 
 @router.get(
-    "/{etype}",
-    responses={400: {"description": "Query can't be processed", "model": ErrorResponse}},
-    deprecated=True,
-)
-async def list_entity_type_eids(
-    etype: str,
-    fulltext_filters: Json = None,
-    generic_filter: Json = None,
-    skip: NonNegativeInt = 0,
-    limit: NonNegativeInt = 20,
-) -> EntityEidList:
-    """List latest snapshots of all `id`s present in database under `etype`.
-
-    Deprecated in favor of `/entity/{etype}/get` and `/entity/{etype}/count` endpoints,
-    which provide more flexibility and better performance.
-
-    See `/entity/{etype}/get` for more information.
-    """
-    fulltext_filters, generic_filter = _validate_snapshot_filters(fulltext_filters, generic_filter)
-
-    try:
-        cursor, total_count = DB.snapshots.get_latest(etype, fulltext_filters, generic_filter)
-        cursor_page = cursor.skip(skip).limit(limit)
-    except DatabaseError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    time_created = None
-
-    # Remove _id field
-    result = [r["last"] for r in cursor_page]
-    for r in result:
-        time_created = r["_time_created"]
-        del r["_time_created"]
-
-    return EntityEidList(
-        time_created=time_created, count=len(result), total_count=total_count, data=result
-    )
-
-
-@router.get(
     "/{etype}/get",
     responses={400: {"description": "Query can't be processed", "model": ErrorResponse}},
 )
@@ -151,7 +111,6 @@ async def get_entity_type_eids(
     """List latest snapshots of all `id`s present in database under `etype`.
 
     Contains only latest snapshot.
-    The `total_count` returned is always 0, use `/entity/{etype}/count` to get total count.
 
     Uses pagination.
     Setting `limit` to 0 is interpreted as no limit (return all results).
@@ -243,7 +202,7 @@ async def get_entity_type_eids(
         time_created = r["_time_created"]
         del r["_time_created"]
 
-    return EntityEidList(time_created=time_created, count=len(result), total_count=0, data=result)
+    return EntityEidList(time_created=time_created, count=len(result), data=result)
 
 
 @router.get(

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -67,12 +67,16 @@ def get_eid_master_record_handler(
 
 
 def get_eid_snapshots_handler(
-    e: EntityId, date_from: Optional[AwareDatetime] = None, date_to: Optional[AwareDatetime] = None
+    e: EntityId,
+    date_from: Optional[AwareDatetime] = None,
+    date_to: Optional[AwareDatetime] = None,
+    skip: int = 0,
+    limit: int = 0,
 ) -> list[dict[str, Any]]:
-    """Handler for getting snapshots of EID"""
-    snapshots = list(DB.snapshots.get_by_eid(e.type, e.id, t1=date_from, t2=date_to))
-
-    return snapshots
+    """Handler for getting snapshots of EID."""
+    return list(
+        DB.snapshots.get_by_eid(e.type, e.id, t1=date_from, t2=date_to, skip=skip, limit=limit)
+    )
 
 
 router = APIRouter(dependencies=[Depends(check_etype)])
@@ -236,7 +240,7 @@ async def count_entity_type_eids(
 async def get_eid_data(
     e: ParsedEid, date_from: Optional[AwareDatetime] = None, date_to: Optional[AwareDatetime] = None
 ) -> EntityEidData:
-    """Get data of `etype`'s `eid`.
+    """Get data of the entity identified by `etype` and `eid`.
 
     Contains all snapshots and master record.
     Snapshots are ordered by ascending creation time.
@@ -256,16 +260,24 @@ async def get_eid_data(
 async def get_eid_master_record(
     e: ParsedEid, date_from: Optional[AwareDatetime] = None, date_to: Optional[AwareDatetime] = None
 ) -> EntityEidMasterRecord:
-    """Get master record of `etype`'s `eid`."""
+    """Get the master record of the entity identified by `etype` and `eid`."""
     return get_eid_master_record_handler(e, date_from, date_to)
 
 
 @router.get("/{etype}/{eid}/snapshots")
 async def get_eid_snapshots(
-    e: ParsedEid, date_from: Optional[AwareDatetime] = None, date_to: Optional[AwareDatetime] = None
+    e: ParsedEid,
+    date_from: Optional[AwareDatetime] = None,
+    date_to: Optional[AwareDatetime] = None,
+    skip: NonNegativeInt = 0,
+    limit: NonNegativeInt = 0,
 ) -> EntityEidSnapshots:
-    """Get snapshots of `etype`'s `eid`."""
-    return get_eid_snapshots_handler(e, date_from, date_to)
+    """Get snapshots of the entity identified by `etype` and `eid`.
+
+    Supports optional pagination via `skip` and `limit`.
+    Setting `limit` to `0` returns all matching snapshots.
+    """
+    return get_eid_snapshots_handler(e, date_from, date_to, skip, limit)
 
 
 @router.get("/{etype}/{eid}/get/{attr}")

--- a/dp3/api/routers/entity.py
+++ b/dp3/api/routers/entity.py
@@ -13,12 +13,14 @@ from dp3.api.internal.entity_response_models import (
     EntityEidList,
     EntityEidMasterRecord,
     EntityEidSnapshots,
+    EntityRawDataPage,
     JsonVal,
 )
 from dp3.api.internal.helpers import api_to_dp3_datapoint
 from dp3.api.internal.models import DataPoint, EntityId, EntityIdAdapter
 from dp3.api.internal.response_models import ErrorResponse, RequestValidationError, SuccessResponse
 from dp3.common.attrspec import AttrType
+from dp3.common.datapoint import to_json_friendly
 from dp3.common.task import DataPointTask, task_context
 from dp3.common.types import UTC, AwareDatetime
 from dp3.database.database import DatabaseError
@@ -40,6 +42,33 @@ async def parse_eid(etype: str, eid: str):
 
 
 ParsedEid = Annotated[EntityId, Depends(parse_eid)]
+
+
+def _parse_optional_eid(etype: str, eid: Optional[str]) -> Any:
+    """Parse optional entity id query parameter for entity-scoped endpoints."""
+    if eid is None:
+        return None
+    try:
+        return EntityIdAdapter.validate_python({"etype": etype, "eid": eid}).id
+    except ValidationError as e:
+        raise RequestValidationError(["query", "eid"], e.errors()[0]["msg"]) from e
+
+
+def _jsonify_raw_value(value: Any) -> Any:
+    """Convert raw datapoint values to JSON-friendly Python objects."""
+    if isinstance(value, dict):
+        return {key: _jsonify_raw_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_jsonify_raw_value(item) for item in value]
+    return to_json_friendly(value)
+
+
+def _raw_datapoint_to_response(raw_datapoint: dict[str, Any]) -> dict[str, Any]:
+    """Convert a raw datapoint document to the API response shape."""
+    payload = {key: _jsonify_raw_value(value) for key, value in raw_datapoint.items()}
+    payload["type"] = payload.pop("etype")
+    payload["id"] = payload.pop("eid")
+    return payload
 
 
 def get_eid_master_record_handler(
@@ -234,6 +263,44 @@ async def count_entity_type_eids(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     return EntityEidCount(total_count=count)
+
+
+@router.get(
+    "/{etype}/raw/get",
+    responses={400: {"description": "Query can't be processed", "model": ErrorResponse}},
+)
+async def get_entity_type_raw_datapoints(
+    etype: str,
+    eid: Optional[str] = None,
+    attr: Optional[str] = None,
+    src: Optional[str] = None,
+    skip: NonNegativeInt = 0,
+    limit: NonNegativeInt = 20,
+) -> EntityRawDataPage:
+    """List raw datapoints from the current raw collection for troubleshooting ingestion."""
+    if attr is not None and attr not in MODEL_SPEC.attribs(etype):
+        raise RequestValidationError(["query", "attr"], f"Attribute '{attr}' doesn't exist")
+
+    parsed_eid = _parse_optional_eid(etype, eid)
+
+    try:
+        datapoints = list(
+            DB.find_raw_datapoints(
+                etype,
+                eid=parsed_eid,
+                attr=attr,
+                src=src,
+                skip=skip,
+                limit=limit,
+            )
+        )
+    except DatabaseError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return EntityRawDataPage(
+        count=len(datapoints),
+        data=[_raw_datapoint_to_response(datapoint) for datapoint in datapoints],
+    )
 
 
 @router.get("/{etype}/{eid}")

--- a/dp3/api/routers/telemetry.py
+++ b/dp3/api/routers/telemetry.py
@@ -1,17 +1,68 @@
 from datetime import datetime
+from typing import Literal, Optional
 
-from fastapi import APIRouter
+import requests
+from fastapi import APIRouter, HTTPException
+from pydantic import NonNegativeInt
 
 from dp3.api.internal.config import TELEMETRY_READER
+from dp3.common.types import AwareDatetime
 
 router = APIRouter()
 
 
 @router.get("/sources_validity")
 async def get_sources_validity() -> dict[str, datetime]:
-    """Get validity of all data sources
+    """Get validity of all data sources.
 
-    Returns timestamps (datetimes) of current validity of all sources.
+    Returns timestamps of current validity of all sources.
     This should be latest `t2` of incoming datapoints for given data source.
     """
     return TELEMETRY_READER.get_sources_validity()
+
+
+@router.get("/sources_age")
+async def get_sources_age(unit: Literal["minutes", "seconds"] = "minutes") -> dict[str, int]:
+    """Get current source ages in requested units."""
+    return TELEMETRY_READER.get_sources_age(unit)
+
+
+@router.get("/entities_per_attr")
+async def get_entities_per_attr() -> dict[str, dict[str, int]]:
+    """Get counts of entities with data present for each configured attribute."""
+    return TELEMETRY_READER.get_entities_per_attr()
+
+
+@router.get("/snapshot_summary")
+async def get_snapshot_summary() -> dict:
+    """Get summary of recent snapshot activity."""
+    return TELEMETRY_READER.get_snapshot_summary()
+
+
+@router.get("/metadata")
+async def get_metadata(
+    module: Optional[str] = None,
+    date_from: Optional[AwareDatetime] = None,
+    date_to: Optional[AwareDatetime] = None,
+    skip: NonNegativeInt = 0,
+    limit: NonNegativeInt = 0,
+    sort: Literal["newest", "oldest"] = "newest",
+) -> list[dict]:
+    """Get filtered metadata documents from the internal metadata collection."""
+    return TELEMETRY_READER.get_metadata(
+        module=module,
+        date_from=date_from,
+        date_to=date_to,
+        newest_first=(sort == "newest"),
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.get("/rabbitmq/queues")
+async def get_rabbitmq_queues() -> dict:
+    """Get RabbitMQ queue telemetry for the running application."""
+    try:
+        return TELEMETRY_READER.get_rabbitmq_queues()
+    except requests.RequestException as e:
+        raise HTTPException(status_code=503, detail=f"RabbitMQ telemetry unavailable: {e}") from e

--- a/dp3/bin/cli.py
+++ b/dp3/bin/cli.py
@@ -4,6 +4,8 @@
 import argparse
 import sys
 
+import argcomplete
+
 from dp3.bin.api import init_parser as init_api_parser
 from dp3.bin.api import main as api_main
 from dp3.bin.check import init_parser as init_check_parser
@@ -72,6 +74,7 @@ def init_parser():
 
 def run():
     parser = init_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     if args.command == "worker":

--- a/dp3/bin/cli.py
+++ b/dp3/bin/cli.py
@@ -14,6 +14,8 @@ from dp3.bin.schema_update import init_parser as init_schema_update_parser
 from dp3.bin.schema_update import main as schema_update_main
 from dp3.bin.setup import init_parser as init_setup_parser
 from dp3.bin.setup import main as setup_main
+from dp3.bin.sh import init_parser as init_sh_parser
+from dp3.bin.sh import main as sh_main
 from dp3.bin.worker import init_parser as init_worker_parser
 from dp3.bin.worker import main as worker_main
 
@@ -58,6 +60,13 @@ def init_parser():
         description="Update the database schema after making conflicting changes to the model. ",
     )
     init_schema_update_parser(schema_update_parser)
+
+    sh_parser = commands.add_parser(
+        "sh",
+        help="Shell-oriented interface to a running DP3 API.",
+        description="Shell-oriented interface to a running DP3 API.",
+    )
+    init_sh_parser(sh_parser)
     return parser
 
 
@@ -77,6 +86,8 @@ def run():
         config_main(args)
     elif args.command == "schema-update":
         schema_update_main(args)
+    elif args.command == "sh":
+        sh_main(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/dp3/bin/config.py
+++ b/dp3/bin/config.py
@@ -148,6 +148,15 @@ def config_supervisor(app_name, config_dir):
     replace_template_file(appctl_path, "{{DP3_APP}}", app_name)
     appctl_path.chmod(0o755)
 
+    appsh_path = Path(f"/usr/bin/{app_name}sh")
+    shutil.copy(
+        package_dir / "template" / "appsh",
+        appsh_path,
+    )
+    replace_template_file(appsh_path, "{{DP3_EXE}}", dp3_executable_path)
+    replace_template_file(appsh_path, "{{CONFIG_DIR}}", str(abs_config_dir))
+    appsh_path.chmod(0o755)
+
 
 def main(args):
     required_args = []

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -10,7 +10,8 @@ from urllib.parse import urljoin
 
 import requests
 
-from dp3.common.config import read_config_dir
+from dp3.common.attrspec import AttrType
+from dp3.common.config import ModelSpec, read_config_dir
 
 
 class APIError(RuntimeError):
@@ -20,8 +21,15 @@ class APIError(RuntimeError):
 class DP3APIClient:
     """Small HTTP client for the DP3 API."""
 
-    def __init__(self, config_dir: str, base_url: Optional[str] = None, timeout: float = 5.0):
+    def __init__(
+        self,
+        config_dir: str,
+        base_url: Optional[str] = None,
+        timeout: float = 5.0,
+        model_spec: Optional[ModelSpec] = None,
+    ):
         self.config_dir = os.path.abspath(config_dir)
+        self.model_spec = model_spec
         self.base_url = self._resolve_base_url(base_url)
         self.timeout = timeout
         self.session = requests.Session()
@@ -182,6 +190,40 @@ def _common_time_params(args) -> dict[str, Any]:
     return params
 
 
+def _read_json_object(raw_value: str, flag_name: str) -> dict[str, Any]:
+    value = _read_json_value(raw_value)
+    if not isinstance(value, dict):
+        raise APIError(f"{flag_name} must decode to a JSON object.")
+    return value
+
+
+def _build_has_attr_filter(client: DP3APIClient, etype: str, attr: str) -> dict[str, Any]:
+    if client.model_spec is None:
+        raise APIError("Attribute-presence filtering requires a readable model specification.")
+    if etype not in client.model_spec.entities:
+        raise APIError(f"Unknown entity type '{etype}'.")
+    if attr not in client.model_spec.attribs(etype):
+        raise APIError(f"Attribute '{attr}' doesn't exist on entity type '{etype}'.")
+
+    query = {f"last.{attr}": {"$exists": True}}
+    attr_spec = client.model_spec.attr(etype, attr)
+    if attr_spec.t in AttrType.TIMESERIES | AttrType.OBSERVATIONS:
+        query[f"last.{attr}"]["$ne"] = []
+    return query
+
+
+def _entity_generic_filter_param(client: DP3APIClient, args) -> Optional[str]:
+    query = None
+    if getattr(args, "filter_json", None) is not None:
+        query = _read_json_object(args.filter_json, "--filter-json")
+    if getattr(args, "has_attr", None) is not None:
+        has_attr_filter = _build_has_attr_filter(client, args.etype, args.has_attr)
+        query = has_attr_filter if query is None else {"$and": [query, has_attr_filter]}
+    if query is None:
+        return None
+    return json.dumps(query)
+
+
 def handle_health(client: DP3APIClient, _args) -> int:
     return _print_response_json(client.request("GET", "/"))
 
@@ -199,8 +241,9 @@ def handle_entity_list(client: DP3APIClient, args) -> int:
     params = {"skip": args.skip, "limit": args.limit}
     if args.fulltext_json is not None:
         params["fulltext_filters"] = args.fulltext_json
-    if args.filter_json is not None:
-        params["generic_filter"] = args.filter_json
+    generic_filter = _entity_generic_filter_param(client, args)
+    if generic_filter is not None:
+        params["generic_filter"] = generic_filter
     return _print_response_json(client.request("GET", f"/entity/{args.etype}/get", params=params))
 
 
@@ -208,9 +251,25 @@ def handle_entity_count(client: DP3APIClient, args) -> int:
     params = {}
     if args.fulltext_json is not None:
         params["fulltext_filters"] = args.fulltext_json
-    if args.filter_json is not None:
-        params["generic_filter"] = args.filter_json
+    generic_filter = _entity_generic_filter_param(client, args)
+    if generic_filter is not None:
+        params["generic_filter"] = generic_filter
     return _print_response_json(client.request("GET", f"/entity/{args.etype}/count", params=params))
+
+
+def handle_entity_raw(client: DP3APIClient, args) -> int:
+    params = {"skip": args.skip, "limit": args.limit}
+    if args.eid is not None:
+        params["eid"] = args.eid
+    if args.attr is not None:
+        params["attr"] = args.attr
+    if args.src is not None:
+        params["src"] = args.src
+    path = f"/entity/{args.etype}/raw/get"
+    if args.format == "ndjson":
+        base_params = {key: value for key, value in params.items() if key not in {"skip", "limit"}}
+        return _stream_json_pages(client, path, base_params, args.skip, args.limit)
+    return _print_response_json(client.request("GET", path, params=params))
 
 
 def handle_entity_get(client: DP3APIClient, args) -> int:
@@ -388,6 +447,11 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
     entity_list_parser.add_argument("etype")
     entity_list_parser.add_argument("--fulltext-json", default=None)
     entity_list_parser.add_argument("--filter-json", default=None)
+    entity_list_parser.add_argument(
+        "--has-attr",
+        default=None,
+        help="Limit results to latest snapshots where the attribute has data present.",
+    )
     entity_list_parser.add_argument("--skip", type=int, default=0)
     entity_list_parser.add_argument("--limit", type=int, default=20)
     entity_list_parser.set_defaults(handler=handle_entity_list)
@@ -396,7 +460,28 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
     entity_count_parser.add_argument("etype")
     entity_count_parser.add_argument("--fulltext-json", default=None)
     entity_count_parser.add_argument("--filter-json", default=None)
+    entity_count_parser.add_argument(
+        "--has-attr",
+        default=None,
+        help="Limit results to latest snapshots where the attribute has data present.",
+    )
     entity_count_parser.set_defaults(handler=handle_entity_count)
+
+    entity_raw_parser = entity_commands.add_parser(
+        "raw",
+        help=(
+            "Browse current raw datapoints for troubleshooting ingestion. "
+            "Can be slow on large raw collections."
+        ),
+    )
+    entity_raw_parser.add_argument("etype")
+    entity_raw_parser.add_argument("--eid")
+    entity_raw_parser.add_argument("--attr")
+    entity_raw_parser.add_argument("--src")
+    entity_raw_parser.add_argument("--skip", type=int, default=0)
+    entity_raw_parser.add_argument("--limit", type=int, default=20)
+    entity_raw_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    entity_raw_parser.set_defaults(handler=handle_entity_raw)
 
     entity_get_parser = entity_commands.add_parser("get", help="Get full entity data.")
     entity_get_parser.add_argument("etype")
@@ -530,13 +615,14 @@ def run() -> None:
 
 def main(args) -> int:
     try:
-        read_config_dir(os.path.abspath(args.config), recursive=True)
+        config = read_config_dir(os.path.abspath(args.config), recursive=True)
+        model_spec = ModelSpec(config.get("db_entities"))
     except Exception as e:
         print(f"Cannot read config directory '{args.config}': {e}", file=sys.stderr)
         return 1
 
     try:
-        client = DP3APIClient(args.config, args.url, args.timeout)
+        client = DP3APIClient(args.config, args.url, args.timeout, model_spec=model_spec)
         return args.handler(client, args)
     except APIError as e:
         print(str(e), file=sys.stderr)

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -43,6 +43,7 @@ def register_completion_parser(commands) -> None:
             shell_name, help=f"Print a {shell_name.capitalize()} completion script."
         )
         shell_parser.add_argument(
+            "-c",
             "--command",
             action="append",
             default=[],
@@ -59,6 +60,7 @@ def register_completion_parser(commands) -> None:
 def init_parser(parser: argparse.ArgumentParser) -> None:
     """Initialize the shell-oriented CLI parser."""
     config_action = parser.add_argument(
+        "-c",
         "--config",
         default=None,
         help=(
@@ -68,11 +70,13 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
     )
     config_action.completer = DirectoriesCompleter()
     parser.add_argument(
+        "-u",
         "--url",
         default=None,
         help="Base URL of the DP3 API. When omitted, localhost defaults are probed.",
     )
     parser.add_argument(
+        "-t",
         "--timeout",
         type=float,
         default=5.0,

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -21,7 +21,7 @@ def render_completion_shellcode(shell_name: str, command_names: list[str]) -> st
 
 def handle_completion(_client, args) -> int:
     """Print shell completion registration code."""
-    sys.stdout.write(render_completion_shellcode(args.shell_name, args.command))
+    sys.stdout.write(render_completion_shellcode(args.shell_name, args.completion_commands))
     if not sys.stdout.isatty():
         sys.stdout.write("\n")
     return 0
@@ -37,24 +37,25 @@ def register_completion_parser(commands) -> None:
             "output in your shell or source it from your shell startup file."
         ),
     )
-    completion_commands = completion_parser.add_subparsers(dest="shell_name", required=True)
-    for shell_name in ["bash", "zsh", "fish"]:
-        shell_parser = completion_commands.add_parser(
-            shell_name, help=f"Print a {shell_name.capitalize()} completion script."
-        )
-        shell_parser.add_argument(
-            "-c",
-            "--command",
-            action="append",
-            default=[],
-            help=(
-                "Command name to register completion for. Repeat to register multiple "
-                "commands. Use 'dp3' for 'dp3 sh' and '<APPNAME>sh' for wrapper commands."
-            ),
-        )
-        shell_parser.set_defaults(
-            handler=handle_completion, requires_api=False, load_model_spec=False
-        )
+    completion_parser.add_argument(
+        "shell_name",
+        help="Shell name.",
+        choices=["bash", "zsh", "fish", "tcsh", "powershell"],
+    )
+    completion_parser.add_argument(
+        "-c",
+        "--command",
+        dest="completion_commands",
+        action="append",
+        default=None,
+        help=(
+            "Command name to register completion for. Repeat to register multiple "
+            "commands. Use 'dp3' for 'dp3 sh' and '<APPNAME>sh' for wrapper commands."
+        ),
+    )
+    completion_parser.set_defaults(
+        handler=handle_completion, requires_api=False, load_model_spec=False
+    )
 
 
 def init_parser(parser: argparse.ArgumentParser) -> None:

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -4,14 +4,61 @@
 import argparse
 import sys
 
+import argcomplete
+from argcomplete.completers import DirectoriesCompleter
+from argcomplete.shell_integration import shellcode
+
 from dp3.bin.shcmd import control, datapoints, entities, entity, health, telemetry
 from dp3.bin.shcmd.common import APIError, DP3APIClient, resolve_config_dir
 from dp3.common.config import ModelSpec, read_config_dir
 
 
+def render_completion_shellcode(shell_name: str, command_names: list[str]) -> str:
+    """Render shell completion registration code using argcomplete."""
+    commands = command_names or ["dp3"]
+    return shellcode(commands, shell=shell_name)
+
+
+def handle_completion(_client, args) -> int:
+    """Print shell completion registration code."""
+    sys.stdout.write(render_completion_shellcode(args.shell_name, args.command))
+    if not sys.stdout.isatty():
+        sys.stdout.write("\n")
+    return 0
+
+
+def register_completion_parser(commands) -> None:
+    """Register shell completion helpers on the root parser."""
+    completion_parser = commands.add_parser(
+        "completion",
+        help="Print shell completion scripts.",
+        description=(
+            "Print shell completion scripts backed by argcomplete. Evaluate the generated "
+            "output in your shell or source it from your shell startup file."
+        ),
+    )
+    completion_commands = completion_parser.add_subparsers(dest="shell_name", required=True)
+    for shell_name in ["bash", "zsh", "fish"]:
+        shell_parser = completion_commands.add_parser(
+            shell_name, help=f"Print a {shell_name.capitalize()} completion script."
+        )
+        shell_parser.add_argument(
+            "--command",
+            action="append",
+            default=[],
+            help=(
+                "Command name to register completion for. Repeat to register multiple "
+                "commands. Use 'dp3' for 'dp3 sh' and '<APPNAME>sh' for wrapper commands."
+            ),
+        )
+        shell_parser.set_defaults(
+            handler=handle_completion, requires_api=False, load_model_spec=False
+        )
+
+
 def init_parser(parser: argparse.ArgumentParser) -> None:
     """Initialize the shell-oriented CLI parser."""
-    parser.add_argument(
+    config_action = parser.add_argument(
         "--config",
         default=None,
         help=(
@@ -19,6 +66,7 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
             "Resolution order: --config, DP3_CONFIG_DIR, ./config."
         ),
     )
+    config_action.completer = DirectoriesCompleter()
     parser.add_argument(
         "--url",
         default=None,
@@ -38,12 +86,14 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
     entity.register_parser(commands)
     control.register_parser(commands)
     telemetry.register_parser(commands)
+    register_completion_parser(commands)
 
 
 def run() -> None:
     """Run the shell-oriented CLI as a standalone script."""
     parser = argparse.ArgumentParser(prog="dp3 sh")
     init_parser(parser)
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     sys.exit(main(args))
 
@@ -58,12 +108,21 @@ def main(args) -> int:
             return exit_code
 
     config_dir = resolve_config_dir(args.config)
-    try:
-        config = read_config_dir(config_dir, recursive=True)
-        model_spec = ModelSpec(config.get("db_entities"))
-    except Exception as e:
-        print(f"Cannot read config directory '{config_dir}': {e}", file=sys.stderr)
-        return 1
+    parsed_args.config_dir = config_dir
+
+    model_spec = None
+    if getattr(parsed_args, "load_model_spec", True):
+        try:
+            config = read_config_dir(config_dir, recursive=True)
+            model_spec = ModelSpec(config.get("db_entities"))
+        except Exception as e:
+            if not getattr(parsed_args, "ignore_config_errors", False):
+                print(f"Cannot read config directory '{config_dir}': {e}", file=sys.stderr)
+                return 1
+    parsed_args.model_spec = model_spec
+
+    if not getattr(parsed_args, "requires_api", True):
+        return parsed_args.handler(None, parsed_args)
 
     try:
         client = DP3APIClient(config_dir, args.url, args.timeout, model_spec=model_spec)

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -2,410 +2,22 @@
 """Shell-oriented CLI for interacting with a running DP3 API."""
 
 import argparse
-import json
-import os
 import sys
-from typing import Any, Optional
-from urllib.parse import urljoin
 
-import requests
-
-from dp3.common.attrspec import AttrType
+from dp3.bin.shcmd import control, datapoints, entities, entity, health, telemetry
+from dp3.bin.shcmd.common import APIError, DP3APIClient, resolve_config_dir
 from dp3.common.config import ModelSpec, read_config_dir
 
 
-class APIError(RuntimeError):
-    """Raised when an API request fails."""
-
-
-class DP3APIClient:
-    """Small HTTP client for the DP3 API."""
-
-    def __init__(
-        self,
-        config_dir: str,
-        base_url: Optional[str] = None,
-        timeout: float = 5.0,
-        model_spec: Optional[ModelSpec] = None,
-    ):
-        self.config_dir = os.path.abspath(config_dir)
-        self.model_spec = model_spec
-        self.base_url = self._resolve_base_url(base_url)
-        self.timeout = timeout
-        self.session = requests.Session()
-
-    @staticmethod
-    def _normalize_base_url(base_url: str) -> str:
-        return base_url.rstrip("/") + "/"
-
-    def _resolve_base_url(self, base_url: Optional[str]) -> str:
-        if base_url is not None:
-            normalized = self._normalize_base_url(base_url)
-            self._check_health(normalized)
-            return normalized
-
-        candidates = [
-            "http://127.0.0.1:8081",
-            "http://localhost:8081",
-            "http://127.0.0.1:8081/api",
-            "http://localhost:8081/api",
-            "http://127.0.0.1:5000",
-            "http://localhost:5000",
-            "http://127.0.0.1:5000/api",
-            "http://localhost:5000/api",
-        ]
-        errors = []
-        for candidate in candidates:
-            normalized = self._normalize_base_url(candidate)
-            try:
-                self._check_health(normalized)
-                return normalized
-            except APIError as e:
-                errors.append(f"- {candidate}: {e}")
-
-        joined_errors = "\n".join(errors)
-        raise APIError(f"Unable to reach a DP3 API. Tried:\n{joined_errors}")
-
-    def _check_health(self, base_url: str) -> None:
-        try:
-            response = requests.get(urljoin(base_url, ""), timeout=2)
-        except requests.RequestException as e:
-            raise APIError(str(e)) from e
-
-        if response.status_code != 200:
-            raise APIError(f"unexpected status {response.status_code}")
-
-    def request(
-        self,
-        method: str,
-        path: str,
-        *,
-        params: dict[str, Any] = None,
-        json_body: Any = None,
-        stream: bool = False,
-    ) -> requests.Response:
-        url = urljoin(self.base_url, path.lstrip("/"))
-        try:
-            response = self.session.request(
-                method,
-                url,
-                params=params,
-                json=json_body,
-                timeout=self.timeout,
-                stream=stream,
-            )
-        except requests.RequestException as e:
-            raise APIError(str(e)) from e
-
-        if response.status_code >= 400:
-            detail = response.text.strip() or f"HTTP {response.status_code}"
-            raise APIError(detail)
-        return response
-
-
-def _read_json_value(raw_value: str) -> Any:
-    try:
-        return json.loads(raw_value)
-    except json.JSONDecodeError as e:
-        raise APIError(f"Invalid JSON value: {e}") from e
-
-
-def _read_json_input(path: Optional[str]) -> Any:
-    if path in (None, "-"):
-        content = sys.stdin.read()
-    else:
-        with open(path, encoding="utf-8") as file_handle:
-            content = file_handle.read()
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError as e:
-        raise APIError(f"Invalid JSON input: {e}") from e
-
-
-def _print_response_json(response: requests.Response) -> int:
-    sys.stdout.write(response.text)
-    if response.text and not response.text.endswith("\n"):
-        sys.stdout.write("\n")
-    return 0
-
-
-def _extract_page_items(payload: Any) -> list[Any]:
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
-        return payload["data"]
-    raise APIError("Expected a list response or an object containing a 'data' list.")
-
-
-def _stream_json_pages(
-    client: DP3APIClient,
-    path: str,
-    params: dict[str, Any],
-    start_skip: int,
-    requested_limit: int,
-    page_size: int = 100,
-) -> int:
-    emitted = 0
-    skip = start_skip
-    remaining = requested_limit
-
-    try:
-        while True:
-            batch_limit = page_size if requested_limit == 0 else min(page_size, remaining)
-            page_params = dict(params)
-            page_params["skip"] = skip
-            page_params["limit"] = batch_limit
-            response = client.request("GET", path, params=page_params)
-            items = _extract_page_items(response.json())
-            if not items:
-                break
-
-            for item in items:
-                sys.stdout.write(json.dumps(item))
-                sys.stdout.write("\n")
-                sys.stdout.flush()
-                emitted += 1
-                if requested_limit != 0 and emitted >= requested_limit:
-                    return 0
-
-            fetched = len(items)
-            skip += fetched
-            if requested_limit != 0:
-                remaining -= fetched
-                if remaining <= 0:
-                    break
-            if fetched < batch_limit:
-                break
-    except BrokenPipeError:
-        return 0
-    return 0
-
-
-def _common_time_params(args) -> dict[str, Any]:
-    params = {}
-    if getattr(args, "date_from", None) is not None:
-        params["date_from"] = args.date_from
-    if getattr(args, "date_to", None) is not None:
-        params["date_to"] = args.date_to
-    return params
-
-
-def _read_json_object(raw_value: str, flag_name: str) -> dict[str, Any]:
-    value = _read_json_value(raw_value)
-    if not isinstance(value, dict):
-        raise APIError(f"{flag_name} must decode to a JSON object.")
-    return value
-
-
-def _build_has_attr_filter(client: DP3APIClient, etype: str, attr: str) -> dict[str, Any]:
-    if client.model_spec is None:
-        raise APIError("Attribute-presence filtering requires a readable model specification.")
-    if etype not in client.model_spec.entities:
-        raise APIError(f"Unknown entity type '{etype}'.")
-    if attr not in client.model_spec.attribs(etype):
-        raise APIError(f"Attribute '{attr}' doesn't exist on entity type '{etype}'.")
-
-    query = {f"last.{attr}": {"$exists": True}}
-    attr_spec = client.model_spec.attr(etype, attr)
-    if attr_spec.t in AttrType.TIMESERIES | AttrType.OBSERVATIONS:
-        query[f"last.{attr}"]["$ne"] = []
-    return query
-
-
-def _entity_generic_filter_param(client: DP3APIClient, args) -> Optional[str]:
-    query = None
-    if getattr(args, "filter_json", None) is not None:
-        query = _read_json_object(args.filter_json, "--filter-json")
-    if getattr(args, "has_attr", None) is not None:
-        has_attr_filter = _build_has_attr_filter(client, args.etype, args.has_attr)
-        query = has_attr_filter if query is None else {"$and": [query, has_attr_filter]}
-    if query is None:
-        return None
-    return json.dumps(query)
-
-
-def handle_health(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/"))
-
-
-def handle_datapoints_ingest(client: DP3APIClient, args) -> int:
-    body = _read_json_input(args.path)
-    return _print_response_json(client.request("POST", "/datapoints", json_body=body))
-
-
-def handle_entity_types(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/entities"))
-
-
-def handle_entity_list(client: DP3APIClient, args) -> int:
-    params = {"skip": args.skip, "limit": args.limit}
-    if args.fulltext_json is not None:
-        params["fulltext_filters"] = args.fulltext_json
-    generic_filter = _entity_generic_filter_param(client, args)
-    if generic_filter is not None:
-        params["generic_filter"] = generic_filter
-    return _print_response_json(client.request("GET", f"/entity/{args.etype}/get", params=params))
-
-
-def handle_entity_count(client: DP3APIClient, args) -> int:
-    params = {}
-    if args.fulltext_json is not None:
-        params["fulltext_filters"] = args.fulltext_json
-    generic_filter = _entity_generic_filter_param(client, args)
-    if generic_filter is not None:
-        params["generic_filter"] = generic_filter
-    return _print_response_json(client.request("GET", f"/entity/{args.etype}/count", params=params))
-
-
-def handle_entity_raw(client: DP3APIClient, args) -> int:
-    params = {"skip": args.skip, "limit": args.limit}
-    if args.eid is not None:
-        params["eid"] = args.eid
-    if args.attr is not None:
-        params["attr"] = args.attr
-    if args.src is not None:
-        params["src"] = args.src
-    path = f"/entity/{args.etype}/raw/get"
-    if args.format == "ndjson":
-        base_params = {key: value for key, value in params.items() if key not in {"skip", "limit"}}
-        return _stream_json_pages(client, path, base_params, args.skip, args.limit)
-    return _print_response_json(client.request("GET", path, params=params))
-
-
-def handle_entity_get(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request("GET", f"/entity/{args.etype}/{args.eid}", params=_common_time_params(args))
-    )
-
-
-def handle_entity_master(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request(
-            "GET", f"/entity/{args.etype}/{args.eid}/master", params=_common_time_params(args)
-        )
-    )
-
-
-def handle_entity_snapshots(client: DP3APIClient, args) -> int:
-    params = _common_time_params(args)
-    params["skip"] = args.skip
-    params["limit"] = args.limit
-    path = f"/entity/{args.etype}/{args.eid}/snapshots"
-    if args.format == "ndjson":
-        return _stream_json_pages(client, path, _common_time_params(args), args.skip, args.limit)
-    return _print_response_json(client.request("GET", path, params=params))
-
-
-def handle_entity_attr(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request(
-            "GET",
-            f"/entity/{args.etype}/{args.eid}/get/{args.attr}",
-            params=_common_time_params(args),
-        )
-    )
-
-
-def handle_entity_distinct(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request("GET", f"/entity/{args.etype}/_/distinct/{args.attr}")
-    )
-
-
-def handle_entity_set(client: DP3APIClient, args) -> int:
-    body = {"value": _read_json_value(args.value_json)}
-    return _print_response_json(
-        client.request("POST", f"/entity/{args.etype}/{args.eid}/set/{args.attr}", json_body=body)
-    )
-
-
-def handle_entity_ttl(client: DP3APIClient, args) -> int:
-    body = _read_json_value(args.body_json)
-    return _print_response_json(
-        client.request("POST", f"/entity/{args.etype}/{args.eid}/ttl", json_body=body)
-    )
-
-
-def handle_entity_delete(client: DP3APIClient, args) -> int:
-    return _print_response_json(client.request("DELETE", f"/entity/{args.etype}/{args.eid}"))
-
-
-def handle_control_make_snapshots(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/control/make_snapshots"))
-
-
-def handle_control_refresh_on_entity_creation(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request(
-            "GET",
-            "/control/refresh_on_entity_creation",
-            params={"etype": args.etype},
-        )
-    )
-
-
-def handle_control_refresh_module_config(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request(
-            "GET",
-            "/control/refresh_module_config",
-            params={"module": args.module},
-        )
-    )
-
-
-def handle_telemetry_sources_validity(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/telemetry/sources_validity"))
-
-
-def handle_telemetry_source_age(client: DP3APIClient, args) -> int:
-    return _print_response_json(
-        client.request("GET", "/telemetry/sources_age", params={"unit": args.unit})
-    )
-
-
-def handle_telemetry_entities_per_attr(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/telemetry/entities_per_attr"))
-
-
-def handle_telemetry_snapshot_summary(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/telemetry/snapshot_summary"))
-
-
-def handle_telemetry_metadata(client: DP3APIClient, args) -> int:
-    params = {
-        "skip": args.skip,
-        "limit": args.limit,
-        "sort": args.sort,
-    }
-    if args.module is not None:
-        params["module"] = args.module
-    if args.date_from is not None:
-        params["date_from"] = args.date_from
-    if args.date_to is not None:
-        params["date_to"] = args.date_to
-
-    if args.format == "ndjson":
-        base_params = {k: v for k, v in params.items() if k not in {"skip", "limit"}}
-        return _stream_json_pages(
-            client,
-            "/telemetry/metadata",
-            base_params,
-            args.skip,
-            args.limit,
-        )
-    return _print_response_json(client.request("GET", "/telemetry/metadata", params=params))
-
-
-def handle_telemetry_rabbitmq_queues(client: DP3APIClient, _args) -> int:
-    return _print_response_json(client.request("GET", "/telemetry/rabbitmq/queues"))
-
-
 def init_parser(parser: argparse.ArgumentParser) -> None:
+    """Initialize the shell-oriented CLI parser."""
     parser.add_argument(
         "--config",
-        required=True,
-        help="Path to the DP3 configuration directory.",
+        default=None,
+        help=(
+            "Path to the DP3 configuration directory. "
+            "Resolution order: --config, DP3_CONFIG_DIR, ./config."
+        ),
     )
     parser.add_argument(
         "--url",
@@ -420,193 +32,16 @@ def init_parser(parser: argparse.ArgumentParser) -> None:
     )
 
     commands = parser.add_subparsers(dest="sh_command", required=True)
-
-    health_parser = commands.add_parser("health", help="Check whether the API is reachable.")
-    health_parser.set_defaults(handler=handle_health)
-
-    datapoints_parser = commands.add_parser("datapoints", help="Send datapoints to the API.")
-    datapoints_commands = datapoints_parser.add_subparsers(dest="datapoints_command", required=True)
-    ingest_parser = datapoints_commands.add_parser(
-        "ingest", help="Post datapoints from JSON input."
-    )
-    ingest_parser.add_argument(
-        "path",
-        nargs="?",
-        default="-",
-        help="Path to a JSON file, or '-' / omitted to read stdin.",
-    )
-    ingest_parser.set_defaults(handler=handle_datapoints_ingest)
-
-    entity_parser = commands.add_parser("entity", help="Inspect and modify entity data.")
-    entity_commands = entity_parser.add_subparsers(dest="entity_command", required=True)
-
-    entity_types_parser = entity_commands.add_parser("types", help="List configured entity types.")
-    entity_types_parser.set_defaults(handler=handle_entity_types)
-
-    entity_list_parser = entity_commands.add_parser("list", help="List latest entity snapshots.")
-    entity_list_parser.add_argument("etype")
-    entity_list_parser.add_argument("--fulltext-json", default=None)
-    entity_list_parser.add_argument("--filter-json", default=None)
-    entity_list_parser.add_argument(
-        "--has-attr",
-        default=None,
-        help="Limit results to latest snapshots where the attribute has data present.",
-    )
-    entity_list_parser.add_argument("--skip", type=int, default=0)
-    entity_list_parser.add_argument("--limit", type=int, default=20)
-    entity_list_parser.set_defaults(handler=handle_entity_list)
-
-    entity_count_parser = entity_commands.add_parser("count", help="Count latest entity snapshots.")
-    entity_count_parser.add_argument("etype")
-    entity_count_parser.add_argument("--fulltext-json", default=None)
-    entity_count_parser.add_argument("--filter-json", default=None)
-    entity_count_parser.add_argument(
-        "--has-attr",
-        default=None,
-        help="Limit results to latest snapshots where the attribute has data present.",
-    )
-    entity_count_parser.set_defaults(handler=handle_entity_count)
-
-    entity_raw_parser = entity_commands.add_parser(
-        "raw",
-        help=(
-            "Browse current raw datapoints for troubleshooting ingestion. "
-            "Can be slow on large raw collections."
-        ),
-    )
-    entity_raw_parser.add_argument("etype")
-    entity_raw_parser.add_argument("--eid")
-    entity_raw_parser.add_argument("--attr")
-    entity_raw_parser.add_argument("--src")
-    entity_raw_parser.add_argument("--skip", type=int, default=0)
-    entity_raw_parser.add_argument("--limit", type=int, default=20)
-    entity_raw_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
-    entity_raw_parser.set_defaults(handler=handle_entity_raw)
-
-    entity_get_parser = entity_commands.add_parser("get", help="Get full entity data.")
-    entity_get_parser.add_argument("etype")
-    entity_get_parser.add_argument("eid")
-    entity_get_parser.add_argument("--from", dest="date_from")
-    entity_get_parser.add_argument("--to", dest="date_to")
-    entity_get_parser.set_defaults(handler=handle_entity_get)
-
-    entity_master_parser = entity_commands.add_parser("master", help="Get an entity master record.")
-    entity_master_parser.add_argument("etype")
-    entity_master_parser.add_argument("eid")
-    entity_master_parser.add_argument("--from", dest="date_from")
-    entity_master_parser.add_argument("--to", dest="date_to")
-    entity_master_parser.set_defaults(handler=handle_entity_master)
-
-    entity_snapshots_parser = entity_commands.add_parser(
-        "snapshots", help="Get snapshots of a single entity."
-    )
-    entity_snapshots_parser.add_argument("etype")
-    entity_snapshots_parser.add_argument("eid")
-    entity_snapshots_parser.add_argument("--from", dest="date_from")
-    entity_snapshots_parser.add_argument("--to", dest="date_to")
-    entity_snapshots_parser.add_argument("--skip", type=int, default=0)
-    entity_snapshots_parser.add_argument("--limit", type=int, default=0)
-    entity_snapshots_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
-    entity_snapshots_parser.set_defaults(handler=handle_entity_snapshots)
-
-    entity_attr_parser = entity_commands.add_parser("attr", help="Get an entity attribute value.")
-    entity_attr_parser.add_argument("etype")
-    entity_attr_parser.add_argument("eid")
-    entity_attr_parser.add_argument("attr")
-    entity_attr_parser.add_argument("--from", dest="date_from")
-    entity_attr_parser.add_argument("--to", dest="date_to")
-    entity_attr_parser.set_defaults(handler=handle_entity_attr)
-
-    entity_distinct_parser = entity_commands.add_parser(
-        "distinct", help="Get distinct latest values of an attribute."
-    )
-    entity_distinct_parser.add_argument("etype")
-    entity_distinct_parser.add_argument("attr")
-    entity_distinct_parser.set_defaults(handler=handle_entity_distinct)
-
-    entity_set_parser = entity_commands.add_parser(
-        "set", help="Set a current entity attribute value."
-    )
-    entity_set_parser.add_argument("etype")
-    entity_set_parser.add_argument("eid")
-    entity_set_parser.add_argument("attr")
-    entity_set_parser.add_argument("--value-json", required=True)
-    entity_set_parser.set_defaults(handler=handle_entity_set)
-
-    entity_ttl_parser = entity_commands.add_parser("ttl", help="Extend entity TTLs.")
-    entity_ttl_parser.add_argument("etype")
-    entity_ttl_parser.add_argument("eid")
-    entity_ttl_parser.add_argument("--body-json", required=True)
-    entity_ttl_parser.set_defaults(handler=handle_entity_ttl)
-
-    entity_delete_parser = entity_commands.add_parser("delete", help="Delete entity data.")
-    entity_delete_parser.add_argument("etype")
-    entity_delete_parser.add_argument("eid")
-    entity_delete_parser.set_defaults(handler=handle_entity_delete)
-
-    control_parser = commands.add_parser("control", help="Execute control actions.")
-    control_commands = control_parser.add_subparsers(dest="control_command", required=True)
-
-    make_snapshots_parser = control_commands.add_parser(
-        "make-snapshots", help="Trigger an out-of-order snapshot run."
-    )
-    make_snapshots_parser.set_defaults(handler=handle_control_make_snapshots)
-
-    refresh_entity_creation_parser = control_commands.add_parser(
-        "refresh-on-entity-creation",
-        help="Re-run entity creation callbacks for an entity type.",
-    )
-    refresh_entity_creation_parser.add_argument("etype")
-    refresh_entity_creation_parser.set_defaults(handler=handle_control_refresh_on_entity_creation)
-
-    refresh_module_config_parser = control_commands.add_parser(
-        "refresh-module-config",
-        help="Reload module configuration.",
-    )
-    refresh_module_config_parser.add_argument("module")
-    refresh_module_config_parser.set_defaults(handler=handle_control_refresh_module_config)
-
-    telemetry_parser = commands.add_parser("telemetry", help="Read operational telemetry.")
-    telemetry_commands = telemetry_parser.add_subparsers(dest="telemetry_command", required=True)
-
-    sources_validity_parser = telemetry_commands.add_parser(
-        "sources-validity", help="Show source validity timestamps."
-    )
-    sources_validity_parser.set_defaults(handler=handle_telemetry_sources_validity)
-
-    source_age_parser = telemetry_commands.add_parser("source-age", help="Show source ages.")
-    source_age_parser.add_argument("--unit", choices=["minutes", "seconds"], default="minutes")
-    source_age_parser.set_defaults(handler=handle_telemetry_source_age)
-
-    entities_per_attr_parser = telemetry_commands.add_parser(
-        "entities-per-attr", help="Count entities with data present for each attribute."
-    )
-    entities_per_attr_parser.set_defaults(handler=handle_telemetry_entities_per_attr)
-
-    snapshot_summary_parser = telemetry_commands.add_parser(
-        "snapshot-summary", help="Show recent snapshot activity summary."
-    )
-    snapshot_summary_parser.set_defaults(handler=handle_telemetry_snapshot_summary)
-
-    metadata_parser = telemetry_commands.add_parser(
-        "metadata", help="Browse internal metadata records."
-    )
-    metadata_parser.add_argument("--module")
-    metadata_parser.add_argument("--from", dest="date_from")
-    metadata_parser.add_argument("--to", dest="date_to")
-    metadata_parser.add_argument("--skip", type=int, default=0)
-    metadata_parser.add_argument("--limit", type=int, default=0)
-    metadata_parser.add_argument("--sort", choices=["newest", "oldest"], default="newest")
-    metadata_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
-    metadata_parser.set_defaults(handler=handle_telemetry_metadata)
-
-    rabbitmq_queues_parser = telemetry_commands.add_parser(
-        "rabbitmq-queues", help="Show RabbitMQ queue telemetry."
-    )
-    rabbitmq_queues_parser.set_defaults(handler=handle_telemetry_rabbitmq_queues)
+    health.register_parser(commands)
+    datapoints.register_parser(commands)
+    entities.register_parser(commands)
+    entity.register_parser(commands)
+    control.register_parser(commands)
+    telemetry.register_parser(commands)
 
 
 def run() -> None:
+    """Run the shell-oriented CLI as a standalone script."""
     parser = argparse.ArgumentParser(prog="dp3 sh")
     init_parser(parser)
     args = parser.parse_args()
@@ -614,16 +49,25 @@ def run() -> None:
 
 
 def main(args) -> int:
+    """Execute a parsed shell-oriented CLI command."""
+    parsed_args = args
+    prepare_args = getattr(args, "prepare_args", None)
+    if prepare_args is not None:
+        parsed_args, exit_code = prepare_args(args)
+        if exit_code is not None:
+            return exit_code
+
+    config_dir = resolve_config_dir(args.config)
     try:
-        config = read_config_dir(os.path.abspath(args.config), recursive=True)
+        config = read_config_dir(config_dir, recursive=True)
         model_spec = ModelSpec(config.get("db_entities"))
     except Exception as e:
-        print(f"Cannot read config directory '{args.config}': {e}", file=sys.stderr)
+        print(f"Cannot read config directory '{config_dir}': {e}", file=sys.stderr)
         return 1
 
     try:
-        client = DP3APIClient(args.config, args.url, args.timeout, model_spec=model_spec)
-        return args.handler(client, args)
+        client = DP3APIClient(config_dir, args.url, args.timeout, model_spec=model_spec)
+        return parsed_args.handler(client, parsed_args)
     except APIError as e:
         print(str(e), file=sys.stderr)
         return 1

--- a/dp3/bin/sh.py
+++ b/dp3/bin/sh.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Shell-oriented CLI for interacting with a running DP3 API."""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from dp3.common.config import read_config_dir
+
+
+class APIError(RuntimeError):
+    """Raised when an API request fails."""
+
+
+class DP3APIClient:
+    """Small HTTP client for the DP3 API."""
+
+    def __init__(self, config_dir: str, base_url: Optional[str] = None, timeout: float = 5.0):
+        self.config_dir = os.path.abspath(config_dir)
+        self.base_url = self._resolve_base_url(base_url)
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        return base_url.rstrip("/") + "/"
+
+    def _resolve_base_url(self, base_url: Optional[str]) -> str:
+        if base_url is not None:
+            normalized = self._normalize_base_url(base_url)
+            self._check_health(normalized)
+            return normalized
+
+        candidates = [
+            "http://127.0.0.1:8081",
+            "http://localhost:8081",
+            "http://127.0.0.1:8081/api",
+            "http://localhost:8081/api",
+            "http://127.0.0.1:5000",
+            "http://localhost:5000",
+            "http://127.0.0.1:5000/api",
+            "http://localhost:5000/api",
+        ]
+        errors = []
+        for candidate in candidates:
+            normalized = self._normalize_base_url(candidate)
+            try:
+                self._check_health(normalized)
+                return normalized
+            except APIError as e:
+                errors.append(f"- {candidate}: {e}")
+
+        joined_errors = "\n".join(errors)
+        raise APIError(f"Unable to reach a DP3 API. Tried:\n{joined_errors}")
+
+    def _check_health(self, base_url: str) -> None:
+        try:
+            response = requests.get(urljoin(base_url, ""), timeout=2)
+        except requests.RequestException as e:
+            raise APIError(str(e)) from e
+
+        if response.status_code != 200:
+            raise APIError(f"unexpected status {response.status_code}")
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] = None,
+        json_body: Any = None,
+        stream: bool = False,
+    ) -> requests.Response:
+        url = urljoin(self.base_url, path.lstrip("/"))
+        try:
+            response = self.session.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                timeout=self.timeout,
+                stream=stream,
+            )
+        except requests.RequestException as e:
+            raise APIError(str(e)) from e
+
+        if response.status_code >= 400:
+            detail = response.text.strip() or f"HTTP {response.status_code}"
+            raise APIError(detail)
+        return response
+
+
+def _read_json_value(raw_value: str) -> Any:
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError as e:
+        raise APIError(f"Invalid JSON value: {e}") from e
+
+
+def _read_json_input(path: Optional[str]) -> Any:
+    if path in (None, "-"):
+        content = sys.stdin.read()
+    else:
+        with open(path, encoding="utf-8") as file_handle:
+            content = file_handle.read()
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        raise APIError(f"Invalid JSON input: {e}") from e
+
+
+def _print_response_json(response: requests.Response) -> int:
+    sys.stdout.write(response.text)
+    if response.text and not response.text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def _extract_page_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        return payload["data"]
+    raise APIError("Expected a list response or an object containing a 'data' list.")
+
+
+def _stream_json_pages(
+    client: DP3APIClient,
+    path: str,
+    params: dict[str, Any],
+    start_skip: int,
+    requested_limit: int,
+    page_size: int = 100,
+) -> int:
+    emitted = 0
+    skip = start_skip
+    remaining = requested_limit
+
+    try:
+        while True:
+            batch_limit = page_size if requested_limit == 0 else min(page_size, remaining)
+            page_params = dict(params)
+            page_params["skip"] = skip
+            page_params["limit"] = batch_limit
+            response = client.request("GET", path, params=page_params)
+            items = _extract_page_items(response.json())
+            if not items:
+                break
+
+            for item in items:
+                sys.stdout.write(json.dumps(item))
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+                emitted += 1
+                if requested_limit != 0 and emitted >= requested_limit:
+                    return 0
+
+            fetched = len(items)
+            skip += fetched
+            if requested_limit != 0:
+                remaining -= fetched
+                if remaining <= 0:
+                    break
+            if fetched < batch_limit:
+                break
+    except BrokenPipeError:
+        return 0
+    return 0
+
+
+def _common_time_params(args) -> dict[str, Any]:
+    params = {}
+    if getattr(args, "date_from", None) is not None:
+        params["date_from"] = args.date_from
+    if getattr(args, "date_to", None) is not None:
+        params["date_to"] = args.date_to
+    return params
+
+
+def handle_health(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/"))
+
+
+def handle_datapoints_ingest(client: DP3APIClient, args) -> int:
+    body = _read_json_input(args.path)
+    return _print_response_json(client.request("POST", "/datapoints", json_body=body))
+
+
+def handle_entity_types(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/entities"))
+
+
+def handle_entity_list(client: DP3APIClient, args) -> int:
+    params = {"skip": args.skip, "limit": args.limit}
+    if args.fulltext_json is not None:
+        params["fulltext_filters"] = args.fulltext_json
+    if args.filter_json is not None:
+        params["generic_filter"] = args.filter_json
+    return _print_response_json(client.request("GET", f"/entity/{args.etype}/get", params=params))
+
+
+def handle_entity_count(client: DP3APIClient, args) -> int:
+    params = {}
+    if args.fulltext_json is not None:
+        params["fulltext_filters"] = args.fulltext_json
+    if args.filter_json is not None:
+        params["generic_filter"] = args.filter_json
+    return _print_response_json(client.request("GET", f"/entity/{args.etype}/count", params=params))
+
+
+def handle_entity_get(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request("GET", f"/entity/{args.etype}/{args.eid}", params=_common_time_params(args))
+    )
+
+
+def handle_entity_master(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request(
+            "GET", f"/entity/{args.etype}/{args.eid}/master", params=_common_time_params(args)
+        )
+    )
+
+
+def handle_entity_snapshots(client: DP3APIClient, args) -> int:
+    params = _common_time_params(args)
+    params["skip"] = args.skip
+    params["limit"] = args.limit
+    path = f"/entity/{args.etype}/{args.eid}/snapshots"
+    if args.format == "ndjson":
+        return _stream_json_pages(client, path, _common_time_params(args), args.skip, args.limit)
+    return _print_response_json(client.request("GET", path, params=params))
+
+
+def handle_entity_attr(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request(
+            "GET",
+            f"/entity/{args.etype}/{args.eid}/get/{args.attr}",
+            params=_common_time_params(args),
+        )
+    )
+
+
+def handle_entity_distinct(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request("GET", f"/entity/{args.etype}/_/distinct/{args.attr}")
+    )
+
+
+def handle_entity_set(client: DP3APIClient, args) -> int:
+    body = {"value": _read_json_value(args.value_json)}
+    return _print_response_json(
+        client.request("POST", f"/entity/{args.etype}/{args.eid}/set/{args.attr}", json_body=body)
+    )
+
+
+def handle_entity_ttl(client: DP3APIClient, args) -> int:
+    body = _read_json_value(args.body_json)
+    return _print_response_json(
+        client.request("POST", f"/entity/{args.etype}/{args.eid}/ttl", json_body=body)
+    )
+
+
+def handle_entity_delete(client: DP3APIClient, args) -> int:
+    return _print_response_json(client.request("DELETE", f"/entity/{args.etype}/{args.eid}"))
+
+
+def handle_control_make_snapshots(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/control/make_snapshots"))
+
+
+def handle_control_refresh_on_entity_creation(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request(
+            "GET",
+            "/control/refresh_on_entity_creation",
+            params={"etype": args.etype},
+        )
+    )
+
+
+def handle_control_refresh_module_config(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request(
+            "GET",
+            "/control/refresh_module_config",
+            params={"module": args.module},
+        )
+    )
+
+
+def handle_telemetry_sources_validity(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/telemetry/sources_validity"))
+
+
+def handle_telemetry_source_age(client: DP3APIClient, args) -> int:
+    return _print_response_json(
+        client.request("GET", "/telemetry/sources_age", params={"unit": args.unit})
+    )
+
+
+def handle_telemetry_entities_per_attr(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/telemetry/entities_per_attr"))
+
+
+def handle_telemetry_snapshot_summary(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/telemetry/snapshot_summary"))
+
+
+def handle_telemetry_metadata(client: DP3APIClient, args) -> int:
+    params = {
+        "skip": args.skip,
+        "limit": args.limit,
+        "sort": args.sort,
+    }
+    if args.module is not None:
+        params["module"] = args.module
+    if args.date_from is not None:
+        params["date_from"] = args.date_from
+    if args.date_to is not None:
+        params["date_to"] = args.date_to
+
+    if args.format == "ndjson":
+        base_params = {k: v for k, v in params.items() if k not in {"skip", "limit"}}
+        return _stream_json_pages(
+            client,
+            "/telemetry/metadata",
+            base_params,
+            args.skip,
+            args.limit,
+        )
+    return _print_response_json(client.request("GET", "/telemetry/metadata", params=params))
+
+
+def handle_telemetry_rabbitmq_queues(client: DP3APIClient, _args) -> int:
+    return _print_response_json(client.request("GET", "/telemetry/rabbitmq/queues"))
+
+
+def init_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the DP3 configuration directory.",
+    )
+    parser.add_argument(
+        "--url",
+        default=None,
+        help="Base URL of the DP3 API. When omitted, localhost defaults are probed.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="HTTP timeout in seconds.",
+    )
+
+    commands = parser.add_subparsers(dest="sh_command", required=True)
+
+    health_parser = commands.add_parser("health", help="Check whether the API is reachable.")
+    health_parser.set_defaults(handler=handle_health)
+
+    datapoints_parser = commands.add_parser("datapoints", help="Send datapoints to the API.")
+    datapoints_commands = datapoints_parser.add_subparsers(dest="datapoints_command", required=True)
+    ingest_parser = datapoints_commands.add_parser(
+        "ingest", help="Post datapoints from JSON input."
+    )
+    ingest_parser.add_argument(
+        "path",
+        nargs="?",
+        default="-",
+        help="Path to a JSON file, or '-' / omitted to read stdin.",
+    )
+    ingest_parser.set_defaults(handler=handle_datapoints_ingest)
+
+    entity_parser = commands.add_parser("entity", help="Inspect and modify entity data.")
+    entity_commands = entity_parser.add_subparsers(dest="entity_command", required=True)
+
+    entity_types_parser = entity_commands.add_parser("types", help="List configured entity types.")
+    entity_types_parser.set_defaults(handler=handle_entity_types)
+
+    entity_list_parser = entity_commands.add_parser("list", help="List latest entity snapshots.")
+    entity_list_parser.add_argument("etype")
+    entity_list_parser.add_argument("--fulltext-json", default=None)
+    entity_list_parser.add_argument("--filter-json", default=None)
+    entity_list_parser.add_argument("--skip", type=int, default=0)
+    entity_list_parser.add_argument("--limit", type=int, default=20)
+    entity_list_parser.set_defaults(handler=handle_entity_list)
+
+    entity_count_parser = entity_commands.add_parser("count", help="Count latest entity snapshots.")
+    entity_count_parser.add_argument("etype")
+    entity_count_parser.add_argument("--fulltext-json", default=None)
+    entity_count_parser.add_argument("--filter-json", default=None)
+    entity_count_parser.set_defaults(handler=handle_entity_count)
+
+    entity_get_parser = entity_commands.add_parser("get", help="Get full entity data.")
+    entity_get_parser.add_argument("etype")
+    entity_get_parser.add_argument("eid")
+    entity_get_parser.add_argument("--from", dest="date_from")
+    entity_get_parser.add_argument("--to", dest="date_to")
+    entity_get_parser.set_defaults(handler=handle_entity_get)
+
+    entity_master_parser = entity_commands.add_parser("master", help="Get an entity master record.")
+    entity_master_parser.add_argument("etype")
+    entity_master_parser.add_argument("eid")
+    entity_master_parser.add_argument("--from", dest="date_from")
+    entity_master_parser.add_argument("--to", dest="date_to")
+    entity_master_parser.set_defaults(handler=handle_entity_master)
+
+    entity_snapshots_parser = entity_commands.add_parser(
+        "snapshots", help="Get snapshots of a single entity."
+    )
+    entity_snapshots_parser.add_argument("etype")
+    entity_snapshots_parser.add_argument("eid")
+    entity_snapshots_parser.add_argument("--from", dest="date_from")
+    entity_snapshots_parser.add_argument("--to", dest="date_to")
+    entity_snapshots_parser.add_argument("--skip", type=int, default=0)
+    entity_snapshots_parser.add_argument("--limit", type=int, default=0)
+    entity_snapshots_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    entity_snapshots_parser.set_defaults(handler=handle_entity_snapshots)
+
+    entity_attr_parser = entity_commands.add_parser("attr", help="Get an entity attribute value.")
+    entity_attr_parser.add_argument("etype")
+    entity_attr_parser.add_argument("eid")
+    entity_attr_parser.add_argument("attr")
+    entity_attr_parser.add_argument("--from", dest="date_from")
+    entity_attr_parser.add_argument("--to", dest="date_to")
+    entity_attr_parser.set_defaults(handler=handle_entity_attr)
+
+    entity_distinct_parser = entity_commands.add_parser(
+        "distinct", help="Get distinct latest values of an attribute."
+    )
+    entity_distinct_parser.add_argument("etype")
+    entity_distinct_parser.add_argument("attr")
+    entity_distinct_parser.set_defaults(handler=handle_entity_distinct)
+
+    entity_set_parser = entity_commands.add_parser(
+        "set", help="Set a current entity attribute value."
+    )
+    entity_set_parser.add_argument("etype")
+    entity_set_parser.add_argument("eid")
+    entity_set_parser.add_argument("attr")
+    entity_set_parser.add_argument("--value-json", required=True)
+    entity_set_parser.set_defaults(handler=handle_entity_set)
+
+    entity_ttl_parser = entity_commands.add_parser("ttl", help="Extend entity TTLs.")
+    entity_ttl_parser.add_argument("etype")
+    entity_ttl_parser.add_argument("eid")
+    entity_ttl_parser.add_argument("--body-json", required=True)
+    entity_ttl_parser.set_defaults(handler=handle_entity_ttl)
+
+    entity_delete_parser = entity_commands.add_parser("delete", help="Delete entity data.")
+    entity_delete_parser.add_argument("etype")
+    entity_delete_parser.add_argument("eid")
+    entity_delete_parser.set_defaults(handler=handle_entity_delete)
+
+    control_parser = commands.add_parser("control", help="Execute control actions.")
+    control_commands = control_parser.add_subparsers(dest="control_command", required=True)
+
+    make_snapshots_parser = control_commands.add_parser(
+        "make-snapshots", help="Trigger an out-of-order snapshot run."
+    )
+    make_snapshots_parser.set_defaults(handler=handle_control_make_snapshots)
+
+    refresh_entity_creation_parser = control_commands.add_parser(
+        "refresh-on-entity-creation",
+        help="Re-run entity creation callbacks for an entity type.",
+    )
+    refresh_entity_creation_parser.add_argument("etype")
+    refresh_entity_creation_parser.set_defaults(handler=handle_control_refresh_on_entity_creation)
+
+    refresh_module_config_parser = control_commands.add_parser(
+        "refresh-module-config",
+        help="Reload module configuration.",
+    )
+    refresh_module_config_parser.add_argument("module")
+    refresh_module_config_parser.set_defaults(handler=handle_control_refresh_module_config)
+
+    telemetry_parser = commands.add_parser("telemetry", help="Read operational telemetry.")
+    telemetry_commands = telemetry_parser.add_subparsers(dest="telemetry_command", required=True)
+
+    sources_validity_parser = telemetry_commands.add_parser(
+        "sources-validity", help="Show source validity timestamps."
+    )
+    sources_validity_parser.set_defaults(handler=handle_telemetry_sources_validity)
+
+    source_age_parser = telemetry_commands.add_parser("source-age", help="Show source ages.")
+    source_age_parser.add_argument("--unit", choices=["minutes", "seconds"], default="minutes")
+    source_age_parser.set_defaults(handler=handle_telemetry_source_age)
+
+    entities_per_attr_parser = telemetry_commands.add_parser(
+        "entities-per-attr", help="Count entities with data present for each attribute."
+    )
+    entities_per_attr_parser.set_defaults(handler=handle_telemetry_entities_per_attr)
+
+    snapshot_summary_parser = telemetry_commands.add_parser(
+        "snapshot-summary", help="Show recent snapshot activity summary."
+    )
+    snapshot_summary_parser.set_defaults(handler=handle_telemetry_snapshot_summary)
+
+    metadata_parser = telemetry_commands.add_parser(
+        "metadata", help="Browse internal metadata records."
+    )
+    metadata_parser.add_argument("--module")
+    metadata_parser.add_argument("--from", dest="date_from")
+    metadata_parser.add_argument("--to", dest="date_to")
+    metadata_parser.add_argument("--skip", type=int, default=0)
+    metadata_parser.add_argument("--limit", type=int, default=0)
+    metadata_parser.add_argument("--sort", choices=["newest", "oldest"], default="newest")
+    metadata_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    metadata_parser.set_defaults(handler=handle_telemetry_metadata)
+
+    rabbitmq_queues_parser = telemetry_commands.add_parser(
+        "rabbitmq-queues", help="Show RabbitMQ queue telemetry."
+    )
+    rabbitmq_queues_parser.set_defaults(handler=handle_telemetry_rabbitmq_queues)
+
+
+def run() -> None:
+    parser = argparse.ArgumentParser(prog="dp3 sh")
+    init_parser(parser)
+    args = parser.parse_args()
+    sys.exit(main(args))
+
+
+def main(args) -> int:
+    try:
+        read_config_dir(os.path.abspath(args.config), recursive=True)
+    except Exception as e:
+        print(f"Cannot read config directory '{args.config}': {e}", file=sys.stderr)
+        return 1
+
+    try:
+        client = DP3APIClient(args.config, args.url, args.timeout)
+        return args.handler(client, args)
+    except APIError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    run()

--- a/dp3/bin/shcmd/__init__.py
+++ b/dp3/bin/shcmd/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+"""Command families for the shell-oriented DP3 CLI."""

--- a/dp3/bin/shcmd/common.py
+++ b/dp3/bin/shcmd/common.py
@@ -255,7 +255,26 @@ def get_completion_context(
     return model_spec, entity_catalog
 
 
-def complete_entity_type_names(prefix: str, parsed_args, **_kwargs) -> list[str]:
+def _entity_type_description(
+    etype: str,
+    model_spec: Optional[ModelSpec],
+    entity_catalog: Optional[dict[str, Any]],
+) -> str:
+    if model_spec is not None and etype in model_spec.entities:
+        entity_spec = model_spec.entity(etype)
+        return f"{entity_spec.name} ({entity_spec.id_data_type.root} ids)"
+    if entity_catalog is not None and etype in entity_catalog:
+        entry = entity_catalog[etype]
+        name = entry.get("name")
+        id_data_type = entry.get("id_data_type")
+        if name and id_data_type:
+            return f"{name} ({id_data_type} ids)"
+        if name:
+            return str(name)
+    return "Configured entity type."
+
+
+def complete_entity_type_names(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
     """Complete entity type names from config or API metadata."""
     model_spec, entity_catalog = get_completion_context(parsed_args)
     if model_spec is not None:
@@ -264,4 +283,8 @@ def complete_entity_type_names(prefix: str, parsed_args, **_kwargs) -> list[str]
         values = sorted(entity_catalog)
     else:
         values = []
-    return [value for value in values if value.startswith(prefix)]
+    return {
+        value: _entity_type_description(value, model_spec, entity_catalog)
+        for value in values
+        if value.startswith(prefix)
+    }

--- a/dp3/bin/shcmd/common.py
+++ b/dp3/bin/shcmd/common.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Shared helpers for the shell-oriented DP3 CLI."""
+
+import json
+import os
+import sys
+from typing import Any, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from dp3.common.config import ModelSpec
+
+
+class APIError(RuntimeError):
+    """Raised when an API request fails."""
+
+
+JSON_LITERAL_HELP = (
+    "'set' requires a JSON literal value, for example '\"hello\"', '42', 'true', or '{\"k\":1}'."
+)
+
+
+class DP3APIClient:
+    """Small HTTP client for the DP3 API."""
+
+    def __init__(
+        self,
+        config_dir: str,
+        base_url: Optional[str] = None,
+        timeout: float = 5.0,
+        model_spec: Optional[ModelSpec] = None,
+    ):
+        self.config_dir = os.path.abspath(config_dir)
+        self.model_spec = model_spec
+        self.base_url = self._resolve_base_url(base_url)
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        return base_url.rstrip("/") + "/"
+
+    def _resolve_base_url(self, base_url: Optional[str]) -> str:
+        if base_url is not None:
+            normalized = self._normalize_base_url(base_url)
+            self._check_health(normalized)
+            return normalized
+
+        candidates = [
+            "http://127.0.0.1:8081",
+            "http://localhost:8081",
+            "http://127.0.0.1:8081/api",
+            "http://localhost:8081/api",
+            "http://127.0.0.1:5000",
+            "http://localhost:5000",
+            "http://127.0.0.1:5000/api",
+            "http://localhost:5000/api",
+        ]
+        errors = []
+        for candidate in candidates:
+            normalized = self._normalize_base_url(candidate)
+            try:
+                self._check_health(normalized)
+                return normalized
+            except APIError as e:
+                errors.append(f"- {candidate}: {e}")
+
+        joined_errors = "\n".join(errors)
+        raise APIError(f"Unable to reach a DP3 API. Tried:\n{joined_errors}")
+
+    def _check_health(self, base_url: str) -> None:
+        try:
+            response = requests.get(urljoin(base_url, ""), timeout=2)
+        except requests.RequestException as e:
+            raise APIError(str(e)) from e
+
+        if response.status_code != 200:
+            raise APIError(f"unexpected status {response.status_code}")
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Any = None,
+        stream: bool = False,
+    ) -> requests.Response:
+        url = urljoin(self.base_url, path.lstrip("/"))
+        try:
+            response = self.session.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                timeout=self.timeout,
+                stream=stream,
+            )
+        except requests.RequestException as e:
+            raise APIError(str(e)) from e
+
+        if response.status_code >= 400:
+            detail = response.text.strip() or f"HTTP {response.status_code}"
+            raise APIError(detail)
+        return response
+
+
+def read_json_value(raw_value: str) -> Any:
+    """Decode a JSON literal from a command-line argument."""
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError as e:
+        raise APIError(f"Invalid JSON value: {e}") from e
+
+
+def read_json_input(path: Optional[str]) -> Any:
+    """Decode JSON from a file path or standard input."""
+    if path in (None, "-"):
+        content = sys.stdin.read()
+    else:
+        with open(path, encoding="utf-8") as file_handle:
+            content = file_handle.read()
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        raise APIError(f"Invalid JSON input: {e}") from e
+
+
+def print_response_json(response: requests.Response) -> int:
+    """Write an API JSON response to standard output."""
+    sys.stdout.write(response.text)
+    if response.text and not response.text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def common_time_params(args) -> dict[str, Any]:
+    """Build shared time-range query parameters from parsed arguments."""
+    params = {}
+    if getattr(args, "date_from", None) is not None:
+        params["date_from"] = args.date_from
+    if getattr(args, "date_to", None) is not None:
+        params["date_to"] = args.date_to
+    return params
+
+
+def read_json_object(raw_value: str, flag_name: str) -> dict[str, Any]:
+    """Decode a JSON object from a command-line argument."""
+    value = read_json_value(raw_value)
+    if not isinstance(value, dict):
+        raise APIError(f"{flag_name} must decode to a JSON object.")
+    return value
+
+
+def _extract_page_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        return payload["data"]
+    raise APIError("Expected a list response or an object containing a 'data' list.")
+
+
+def stream_json_pages(
+    client: DP3APIClient,
+    path: str,
+    params: dict[str, Any],
+    start_skip: int,
+    requested_limit: int,
+    page_size: int = 100,
+) -> int:
+    """Stream paged JSON API results as NDJSON."""
+    emitted = 0
+    skip = start_skip
+    remaining = requested_limit
+
+    try:
+        while True:
+            batch_limit = page_size if requested_limit == 0 else min(page_size, remaining)
+            page_params = dict(params)
+            page_params["skip"] = skip
+            page_params["limit"] = batch_limit
+            response = client.request("GET", path, params=page_params)
+            items = _extract_page_items(response.json())
+            if not items:
+                break
+
+            for item in items:
+                sys.stdout.write(json.dumps(item))
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+                emitted += 1
+                if requested_limit != 0 and emitted >= requested_limit:
+                    return 0
+
+            fetched = len(items)
+            skip += fetched
+            if requested_limit != 0:
+                remaining -= fetched
+                if remaining <= 0:
+                    break
+            if fetched < batch_limit:
+                break
+    except BrokenPipeError:
+        return 0
+    return 0
+
+
+def resolve_config_dir(config_dir: Optional[str]) -> str:
+    """Resolve the configuration directory for the shell-oriented CLI."""
+    if config_dir is not None:
+        return os.path.abspath(config_dir)
+    if os.environ.get("DP3_CONFIG_DIR"):
+        return os.path.abspath(os.environ["DP3_CONFIG_DIR"])
+    return os.path.abspath("config")

--- a/dp3/bin/shcmd/common.py
+++ b/dp3/bin/shcmd/common.py
@@ -4,12 +4,13 @@
 import json
 import os
 import sys
+from functools import lru_cache
 from typing import Any, Optional
 from urllib.parse import urljoin
 
 import requests
 
-from dp3.common.config import ModelSpec
+from dp3.common.config import ModelSpec, read_config_dir
 
 
 class APIError(RuntimeError):
@@ -213,3 +214,54 @@ def resolve_config_dir(config_dir: Optional[str]) -> str:
     if os.environ.get("DP3_CONFIG_DIR"):
         return os.path.abspath(os.environ["DP3_CONFIG_DIR"])
     return os.path.abspath("config")
+
+
+@lru_cache(maxsize=32)
+def load_completion_model_spec(config_dir: str) -> Optional[ModelSpec]:
+    """Load the model specification used by shell completion."""
+    try:
+        config = read_config_dir(config_dir, recursive=True)
+        return ModelSpec(config.get("db_entities"))
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=32)
+def load_completion_entity_catalog(
+    config_dir: str, base_url: Optional[str], timeout: float
+) -> Optional[dict[str, Any]]:
+    """Load entity metadata from the API when config-based completion is unavailable."""
+    try:
+        client = DP3APIClient(config_dir, base_url, timeout)
+        payload = client.request("GET", "/entities").json()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def get_completion_context(
+    parsed_args,
+) -> tuple[Optional[ModelSpec], Optional[dict[str, Any]]]:
+    """Return completion metadata derived from config and API sources."""
+    config_dir = resolve_config_dir(getattr(parsed_args, "config", None))
+    model_spec = load_completion_model_spec(config_dir)
+    entity_catalog = None
+    if model_spec is None:
+        entity_catalog = load_completion_entity_catalog(
+            config_dir,
+            getattr(parsed_args, "url", None),
+            getattr(parsed_args, "timeout", 5.0),
+        )
+    return model_spec, entity_catalog
+
+
+def complete_entity_type_names(prefix: str, parsed_args, **_kwargs) -> list[str]:
+    """Complete entity type names from config or API metadata."""
+    model_spec, entity_catalog = get_completion_context(parsed_args)
+    if model_spec is not None:
+        values = sorted(model_spec.entities)
+    elif entity_catalog is not None:
+        values = sorted(entity_catalog)
+    else:
+        values = []
+    return [value for value in values if value.startswith(prefix)]

--- a/dp3/bin/shcmd/control.py
+++ b/dp3/bin/shcmd/control.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Control commands for the shell-oriented DP3 CLI."""
+
+from dp3.bin.shcmd.common import print_response_json
+
+
+def handle_make_snapshots(client, _args) -> int:
+    """Trigger an out-of-order snapshot run."""
+    return print_response_json(client.request("GET", "/control/make_snapshots"))
+
+
+def handle_refresh_on_entity_creation(client, args) -> int:
+    """Re-run entity-creation callbacks for an entity type."""
+    return print_response_json(
+        client.request(
+            "GET",
+            "/control/refresh_on_entity_creation",
+            params={"etype": args.etype},
+        )
+    )
+
+
+def handle_refresh_module_config(client, args) -> int:
+    """Reload configuration for one module."""
+    return print_response_json(
+        client.request(
+            "GET",
+            "/control/refresh_module_config",
+            params={"module": args.module},
+        )
+    )
+
+
+def register_parser(commands) -> None:
+    """Register control commands on the root parser."""
+    control_parser = commands.add_parser("control", help="Execute control actions.")
+    control_commands = control_parser.add_subparsers(dest="control_command", required=True)
+
+    make_snapshots_parser = control_commands.add_parser(
+        "make-snapshots", help="Trigger an out-of-order snapshot run."
+    )
+    make_snapshots_parser.set_defaults(handler=handle_make_snapshots)
+
+    refresh_entity_creation_parser = control_commands.add_parser(
+        "refresh-on-entity-creation",
+        help="Re-run entity creation callbacks for an entity type.",
+    )
+    refresh_entity_creation_parser.add_argument("etype")
+    refresh_entity_creation_parser.set_defaults(handler=handle_refresh_on_entity_creation)
+
+    refresh_module_config_parser = control_commands.add_parser(
+        "refresh-module-config",
+        help="Reload module configuration.",
+    )
+    refresh_module_config_parser.add_argument("module")
+    refresh_module_config_parser.set_defaults(handler=handle_refresh_module_config)

--- a/dp3/bin/shcmd/control.py
+++ b/dp3/bin/shcmd/control.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Control commands for the shell-oriented DP3 CLI."""
 
-from dp3.bin.shcmd.common import print_response_json
+from dp3.bin.shcmd.common import complete_entity_type_names, print_response_json
 
 
 def handle_make_snapshots(client, _args) -> int:
@@ -45,7 +45,8 @@ def register_parser(commands) -> None:
         "refresh-on-entity-creation",
         help="Re-run entity creation callbacks for an entity type.",
     )
-    refresh_entity_creation_parser.add_argument("etype")
+    etype_action = refresh_entity_creation_parser.add_argument("etype")
+    etype_action.completer = complete_entity_type_names
     refresh_entity_creation_parser.set_defaults(handler=handle_refresh_on_entity_creation)
 
     refresh_module_config_parser = control_commands.add_parser(

--- a/dp3/bin/shcmd/datapoints.py
+++ b/dp3/bin/shcmd/datapoints.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Datapoint commands for the shell-oriented DP3 CLI."""
+
+from dp3.bin.shcmd.common import print_response_json, read_json_input
+
+
+def handle_datapoints_ingest(client, args) -> int:
+    """Send datapoints from JSON input to the API."""
+    body = read_json_input(args.path)
+    return print_response_json(client.request("POST", "/datapoints", json_body=body))
+
+
+def register_parser(commands) -> None:
+    """Register datapoint commands on the root parser."""
+    datapoints_parser = commands.add_parser("datapoints", help="Send datapoints to the API.")
+    datapoints_commands = datapoints_parser.add_subparsers(dest="datapoints_command", required=True)
+
+    ingest_parser = datapoints_commands.add_parser(
+        "ingest", help="Post datapoints from JSON input."
+    )
+    ingest_parser.add_argument(
+        "path",
+        nargs="?",
+        default="-",
+        help="Path to a JSON file, or '-' / omitted to read stdin.",
+    )
+    ingest_parser.set_defaults(handler=handle_datapoints_ingest)

--- a/dp3/bin/shcmd/datapoints.py
+++ b/dp3/bin/shcmd/datapoints.py
@@ -4,7 +4,7 @@
 from dp3.bin.shcmd.common import print_response_json, read_json_input
 
 
-def handle_datapoints_ingest(client, args) -> int:
+def handle_datapoints(client, args) -> int:
     """Send datapoints from JSON input to the API."""
     body = read_json_input(args.path)
     return print_response_json(client.request("POST", "/datapoints", json_body=body))
@@ -12,16 +12,15 @@ def handle_datapoints_ingest(client, args) -> int:
 
 def register_parser(commands) -> None:
     """Register datapoint commands on the root parser."""
-    datapoints_parser = commands.add_parser("datapoints", help="Send datapoints to the API.")
-    datapoints_commands = datapoints_parser.add_subparsers(dest="datapoints_command", required=True)
-
-    ingest_parser = datapoints_commands.add_parser(
-        "ingest", help="Post datapoints from JSON input."
+    datapoints_parser = commands.add_parser(
+        "datapoints",
+        help="Post datapoints from JSON input.",
+        description="Post datapoints from JSON input.",
     )
-    ingest_parser.add_argument(
+    datapoints_parser.add_argument(
         "path",
         nargs="?",
         default="-",
         help="Path to a JSON file, or '-' / omitted to read stdin.",
     )
-    ingest_parser.set_defaults(handler=handle_datapoints_ingest)
+    datapoints_parser.set_defaults(handler=handle_datapoints)

--- a/dp3/bin/shcmd/entities.py
+++ b/dp3/bin/shcmd/entities.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Entity catalog commands for the shell-oriented DP3 CLI."""
+
+from dp3.bin.shcmd.common import print_response_json
+
+
+def handle_entities(client, _args) -> int:
+    """Return the full entity-type map exposed by the API."""
+    return print_response_json(client.request("GET", "/entities"))
+
+
+def register_parser(commands) -> None:
+    """Register entity catalog commands on the root parser."""
+    entities_parser = commands.add_parser(
+        "entities",
+        help="Return the full entity-type map exposed by the API.",
+        description=(
+            "Return the full entity-type map exposed by the API. To print only entity "
+            "type names, use 'dp3 sh entities | jq keys' or '<APPNAME>sh entities | jq "
+            "keys'."
+        ),
+    )
+    entities_parser.set_defaults(handler=handle_entities)

--- a/dp3/bin/shcmd/entity/__init__.py
+++ b/dp3/bin/shcmd/entity/__init__.py
@@ -5,6 +5,7 @@ import argparse
 from typing import Optional
 
 from . import etype, instance
+from .common import complete_entity_rest, complete_entity_selector
 
 
 def _build_overview_parser() -> argparse.ArgumentParser:
@@ -15,8 +16,12 @@ def _build_overview_parser() -> argparse.ArgumentParser:
             "then continue with either type-scope commands or an entity id."
         ),
     )
-    parser.add_argument("selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type.")
-    parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    selector_action = parser.add_argument(
+        "selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type."
+    )
+    selector_action.completer = complete_entity_selector
+    rest_action = parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    rest_action.completer = complete_entity_rest
     return parser
 
 
@@ -58,6 +63,10 @@ def register_parser(commands) -> None:
         help="Inspect and modify entity data.",
         description=overview_parser.description,
     )
-    entity_parser.add_argument("selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type.")
-    entity_parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    selector_action = entity_parser.add_argument(
+        "selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type."
+    )
+    selector_action.completer = complete_entity_selector
+    rest_action = entity_parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    rest_action.completer = complete_entity_rest
     entity_parser.set_defaults(handler=handle_entity_command, prepare_args=parse_entity_command)

--- a/dp3/bin/shcmd/entity/__init__.py
+++ b/dp3/bin/shcmd/entity/__init__.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Entity commands for the shell-oriented DP3 CLI."""
+
+import argparse
+from typing import Optional
+
+from . import etype, instance
+
+
+def _build_overview_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dp3 sh entity",
+        description=(
+            "Inspect and modify entity data. Use 'dp3 sh entities' to list entity types, "
+            "then continue with either type-scope commands or an entity id."
+        ),
+    )
+    parser.add_argument("selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type.")
+    parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    return parser
+
+
+def parse_entity_command(args) -> tuple[Optional[argparse.Namespace], Optional[int]]:
+    """Parse the path-like entity command grammar."""
+    overview_parser = _build_overview_parser()
+    if args.selector is None:
+        overview_parser.print_help()
+        return None, 2
+
+    entity_type = args.selector
+    if not args.rest:
+        etype.build_parser(entity_type).print_help()
+        return None, 2
+
+    first = args.rest[0]
+    if first in etype.TYPE_COMMANDS:
+        parsed = etype.build_parser(entity_type).parse_args(args.rest)
+    else:
+        eid = first
+        if len(args.rest) == 1:
+            instance.build_parser(entity_type, eid).print_help()
+            return None, 2
+        parsed = instance.build_parser(entity_type, eid).parse_args(args.rest[1:])
+
+    return parsed, None
+
+
+def handle_entity_command(_client, _args) -> int:
+    """Placeholder for the top-level entity parser before nested parsing runs."""
+    raise RuntimeError("Entity commands must be parsed before execution.")
+
+
+def register_parser(commands) -> None:
+    """Register entity commands on the root parser."""
+    overview_parser = _build_overview_parser()
+    entity_parser = commands.add_parser(
+        "entity",
+        help="Inspect and modify entity data.",
+        description=overview_parser.description,
+    )
+    entity_parser.add_argument("selector", nargs="?", metavar="ENTITY_TYPE", help="Entity type.")
+    entity_parser.add_argument("rest", nargs=argparse.REMAINDER, metavar="...")
+    entity_parser.set_defaults(handler=handle_entity_command, prepare_args=parse_entity_command)

--- a/dp3/bin/shcmd/entity/__init__.py
+++ b/dp3/bin/shcmd/entity/__init__.py
@@ -4,7 +4,7 @@
 import argparse
 from typing import Optional
 
-from . import etype, instance
+from . import etype
 from .common import complete_entity_rest, complete_entity_selector
 
 
@@ -13,7 +13,7 @@ def _build_overview_parser() -> argparse.ArgumentParser:
         prog="dp3 sh entity",
         description=(
             "Inspect and modify entity data. Use 'dp3 sh entities' to list entity types, "
-            "then continue with either type-scope commands or an entity id."
+            "then continue with a type-scope command or 'id' for a single entity."
         ),
     )
     selector_action = parser.add_argument(
@@ -37,16 +37,7 @@ def parse_entity_command(args) -> tuple[Optional[argparse.Namespace], Optional[i
         etype.build_parser(entity_type).print_help()
         return None, 2
 
-    first = args.rest[0]
-    if first in etype.TYPE_COMMANDS:
-        parsed = etype.build_parser(entity_type).parse_args(args.rest)
-    else:
-        eid = first
-        if len(args.rest) == 1:
-            instance.build_parser(entity_type, eid).print_help()
-            return None, 2
-        parsed = instance.build_parser(entity_type, eid).parse_args(args.rest[1:])
-
+    parsed = etype.build_parser(entity_type).parse_args(args.rest)
     return parsed, None
 
 

--- a/dp3/bin/shcmd/entity/attr.py
+++ b/dp3/bin/shcmd/entity/attr.py
@@ -23,18 +23,18 @@ def handle_get(client, args) -> int:
     )
 
 
-def add_instance_attr_parser(commands, etype: str, eid: str) -> None:
+def add_instance_attr_parser(commands, etype: str) -> None:
     """Register entity attribute commands under a single-entity parser."""
     attr_parser = commands.add_parser("attr", help="Get or modify an entity attribute value.")
-    attr_parser.set_defaults(etype=etype, eid=eid)
+    attr_parser.set_defaults(etype=etype)
     attr_action = attr_parser.add_argument("attr", metavar="ATTR")
     attr_action.completer = complete_entity_attr_names
     attr_commands = attr_parser.add_subparsers(dest="entity_attr_command", required=True)
 
     get_parser = attr_commands.add_parser("get", help="Get an entity attribute value.")
     add_time_range_args(get_parser)
-    get_parser.set_defaults(handler=handle_get, etype=etype, eid=eid)
+    get_parser.set_defaults(handler=handle_get, etype=etype)
 
     set_parser = attr_commands.add_parser("set", help="Set a current entity attribute value.")
     add_entity_attr_set_args(set_parser)
-    set_parser.set_defaults(handler=handle_attr_set_request, etype=etype, eid=eid)
+    set_parser.set_defaults(handler=handle_attr_set_request, etype=etype)

--- a/dp3/bin/shcmd/entity/attr.py
+++ b/dp3/bin/shcmd/entity/attr.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Entity attribute-scope commands for the shell-oriented DP3 CLI."""
+
+
+from dp3.bin.shcmd.common import common_time_params, print_response_json
+
+from .common import add_entity_attr_set_args, add_time_range_args, handle_attr_set_request
+
+
+def handle_get(client, args) -> int:
+    """Get one attribute value for one entity."""
+    return print_response_json(
+        client.request(
+            "GET",
+            f"/entity/{args.etype}/{args.eid}/get/{args.attr}",
+            params=common_time_params(args),
+        )
+    )
+
+
+def add_instance_attr_parser(commands, etype: str, eid: str) -> None:
+    """Register entity attribute commands under a single-entity parser."""
+    attr_parser = commands.add_parser("attr", help="Get or modify an entity attribute value.")
+    attr_parser.add_argument("attr", metavar="ATTR")
+    attr_commands = attr_parser.add_subparsers(dest="entity_attr_command", required=True)
+
+    get_parser = attr_commands.add_parser("get", help="Get an entity attribute value.")
+    add_time_range_args(get_parser)
+    get_parser.set_defaults(handler=handle_get, etype=etype, eid=eid)
+
+    set_parser = attr_commands.add_parser("set", help="Set a current entity attribute value.")
+    add_entity_attr_set_args(set_parser)
+    set_parser.set_defaults(handler=handle_attr_set_request, etype=etype, eid=eid)

--- a/dp3/bin/shcmd/entity/attr.py
+++ b/dp3/bin/shcmd/entity/attr.py
@@ -4,7 +4,12 @@
 
 from dp3.bin.shcmd.common import common_time_params, print_response_json
 
-from .common import add_entity_attr_set_args, add_time_range_args, handle_attr_set_request
+from .common import (
+    add_entity_attr_set_args,
+    add_time_range_args,
+    complete_entity_attr_names,
+    handle_attr_set_request,
+)
 
 
 def handle_get(client, args) -> int:
@@ -21,7 +26,9 @@ def handle_get(client, args) -> int:
 def add_instance_attr_parser(commands, etype: str, eid: str) -> None:
     """Register entity attribute commands under a single-entity parser."""
     attr_parser = commands.add_parser("attr", help="Get or modify an entity attribute value.")
-    attr_parser.add_argument("attr", metavar="ATTR")
+    attr_parser.set_defaults(etype=etype, eid=eid)
+    attr_action = attr_parser.add_argument("attr", metavar="ATTR")
+    attr_action.completer = complete_entity_attr_names
     attr_commands = attr_parser.add_subparsers(dest="entity_attr_command", required=True)
 
     get_parser = attr_commands.add_parser("get", help="Get an entity attribute value.")

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -317,17 +317,6 @@ def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
         return {}
 
     from . import etype as entity_etype
-    from . import instance as entity_instance
 
     words = list(getattr(parsed_args, "rest", []))
-    type_parser = entity_etype.build_parser(etype)
-    if not words:
-        matches = _complete_from_parser(type_parser, [], prefix, parsed_args)
-        if not prefix or not prefix.startswith("-"):
-            matches[ENTITY_ID_PLACEHOLDER] = "Enter an entity id to inspect one entity."
-        return matches
-    if words[0] in entity_etype.TYPE_COMMANDS:
-        return _complete_from_parser(type_parser, words, prefix, parsed_args)
-
-    instance_parser = entity_instance.build_parser(etype, words[0])
-    return _complete_from_parser(instance_parser, words[1:], prefix, parsed_args)
+    return _complete_from_parser(entity_etype.build_parser(etype), words, prefix, parsed_args)

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -39,12 +39,14 @@ def add_time_range_args(
 ) -> None:
     """Add common time-range arguments to a parser."""
     from_action = parser.add_argument(
+        "-f",
         "--from",
         dest="date_from",
         help=f"Lower bound of the {scope}.",
     )
     from_action.completer = suppress_completion
     to_action = parser.add_argument(
+        "-t",
         "--to",
         dest="date_to",
         help=f"Upper bound of the {scope}.",
@@ -60,6 +62,7 @@ def add_page_args(
 ) -> None:
     """Add common paging arguments to a parser."""
     skip_action = parser.add_argument(
+        "-s",
         "--skip",
         type=int,
         default=0,
@@ -67,6 +70,7 @@ def add_page_args(
     )
     skip_action.completer = suppress_completion
     limit_action = parser.add_argument(
+        "-l",
         "--limit",
         type=int,
         default=default_limit,
@@ -78,6 +82,7 @@ def add_page_args(
 def add_ndjson_format_arg(parser: argparse.ArgumentParser) -> None:
     """Add common JSON/NDJSON output selection."""
     parser.add_argument(
+        "-F",
         "--format",
         choices=["json", "ndjson"],
         default="json",
@@ -88,11 +93,16 @@ def add_ndjson_format_arg(parser: argparse.ArgumentParser) -> None:
 def add_raw_filter_args(parser: argparse.ArgumentParser) -> None:
     """Add common raw datapoint filters to a parser."""
     attr_action = parser.add_argument(
+        "-a",
         "--attr",
         help="Limit raw datapoints to one attribute.",
     )
     attr_action.completer = complete_entity_attr_names
-    src_action = parser.add_argument("--src", help="Limit raw datapoints to one source.")
+    src_action = parser.add_argument(
+        "-r",
+        "--src",
+        help="Limit raw datapoints to one source.",
+    )
     src_action.completer = suppress_completion
 
 
@@ -104,18 +114,21 @@ def add_type_filter_args(
 ) -> None:
     """Add common entity-type filters to a parser."""
     fulltext_action = parser.add_argument(
+        "-q",
         "--fulltext-json",
         default=None,
         help="JSON object with fulltext search filters.",
     )
     fulltext_action.completer = suppress_completion
     filter_action = parser.add_argument(
+        "-j",
         "--filter-json",
         default=None,
         help="JSON object with additional generic filters.",
     )
     filter_action.completer = suppress_completion
     has_attr_action = parser.add_argument(
+        "-a",
         "--has-attr",
         default=None,
         help="Limit results to latest snapshots where the attribute has data present.",
@@ -207,6 +220,7 @@ def add_entity_attr_set_args(parser: argparse.ArgumentParser) -> None:
     value_action = parser.add_argument("value_json", metavar="VALUE_JSON", help=ATTR_VALUE_HELP)
     value_action.completer = suppress_completion
     value_flag_action = parser.add_argument(
+        "-v",
         "--value-json",
         dest="value_json_flag",
         help=argparse.SUPPRESS,

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -31,6 +31,50 @@ TYPE_COUNT_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr"]
 RAW_OPTIONS = ["--attr", "--src", "--skip", "--limit", "--format"]
 TIME_RANGE_OPTIONS = ["--from", "--to"]
 SNAPSHOT_OPTIONS = ["--from", "--to", "--skip", "--limit", "--format"]
+TYPE_COMMAND_DESCRIPTIONS = {
+    "list": "List latest entity snapshots for the entity type.",
+    "count": "Count latest entity snapshots for the entity type.",
+    "raw": RAW_HELP,
+    "attr": "Query one attribute across the entity type.",
+}
+INSTANCE_COMMAND_DESCRIPTIONS = {
+    "get": "Get the combined entity view.",
+    "master": "Get the current master record.",
+    "snapshots": "Browse snapshots of a single entity.",
+    "raw": RAW_HELP,
+    "ttl": "Extend TTL values for the entity.",
+    "delete": "Delete the entity data.",
+    "attr": "Get or modify one entity attribute.",
+}
+TYPE_OPTION_DESCRIPTIONS = {
+    "--fulltext-json": "JSON object with fulltext search filters.",
+    "--filter-json": "JSON object with additional generic filters.",
+    "--has-attr": "Limit results to entities where the attribute has data present.",
+    "--skip": "Skip this many results before returning data.",
+    "--limit": "Return at most this many results.",
+}
+RAW_OPTION_DESCRIPTIONS = {
+    "--attr": "Limit raw datapoints to one attribute.",
+    "--src": "Limit raw datapoints to one source.",
+    "--skip": "Skip this many raw datapoints before returning data.",
+    "--limit": "Return at most this many raw datapoints.",
+    "--format": "Choose JSON or NDJSON output.",
+}
+TIME_RANGE_OPTION_DESCRIPTIONS = {
+    "--from": "Lower bound of the time range.",
+    "--to": "Upper bound of the time range.",
+}
+SNAPSHOT_OPTION_DESCRIPTIONS = {
+    "--from": "Lower bound of the snapshot time range.",
+    "--to": "Upper bound of the snapshot time range.",
+    "--skip": "Skip this many snapshots before returning data.",
+    "--limit": "Return at most this many snapshots.",
+    "--format": "Choose JSON or NDJSON output.",
+}
+VALUE_CHOICE_DESCRIPTIONS = {
+    "json": "Return structured JSON output.",
+    "ndjson": "Return newline-delimited JSON output.",
+}
 
 
 def add_time_range_args(parser: argparse.ArgumentParser) -> None:
@@ -169,6 +213,10 @@ def _filter_matches(values: Iterable[str], prefix: str) -> list[str]:
     return [value for value in values if value.startswith(prefix)]
 
 
+def _match_descriptions(values: dict[str, str], prefix: str) -> dict[str, str]:
+    return {value: description for value, description in values.items() if value.startswith(prefix)}
+
+
 def _entity_types(model_spec, entity_catalog: Optional[dict[str, Any]] = None) -> list[str]:
     if model_spec is not None:
         return sorted(model_spec.entities)
@@ -187,38 +235,80 @@ def _entity_attrs(
     return []
 
 
+def _entity_attr_descriptions(
+    model_spec, etype: str, entity_catalog: Optional[dict[str, Any]] = None
+) -> dict[str, str]:
+    attrs = _entity_attrs(model_spec, etype, entity_catalog)
+    descriptions = {attr: f"Attribute on entity type '{etype}'." for attr in attrs}
+    if model_spec is not None and etype in model_spec.entities:
+        for attr in attrs:
+            attr_spec = model_spec.attr(etype, attr)
+            descriptions[attr] = f"{attr_spec.t.name.lower()} attribute on entity type '{etype}'."
+    return descriptions
+
+
 def _complete_options(
     args: Sequence[str],
     prefix: str,
     *,
     options: Sequence[str],
+    option_descriptions: Optional[dict[str, str]] = None,
     value_choices: Optional[dict[str, Sequence[str]]] = None,
-) -> list[str]:
+    value_descriptions: Optional[dict[str, dict[str, str]]] = None,
+) -> dict[str, str]:
+    option_descriptions = option_descriptions or {}
     value_choices = value_choices or {}
+    value_descriptions = value_descriptions or {}
     if args and args[-1] in value_choices:
-        return _filter_matches(value_choices[args[-1]], prefix)
-    return _filter_matches(options, prefix)
+        choices = value_choices[args[-1]]
+        descriptions = value_descriptions.get(args[-1], {})
+        return {
+            choice: descriptions.get(choice, f"Value for {args[-1]}.")
+            for choice in choices
+            if choice.startswith(prefix)
+        }
+    return {
+        option: option_descriptions.get(option, "Command option.")
+        for option in options
+        if option.startswith(prefix)
+    }
 
 
-def complete_entity_selector(prefix: str, parsed_args, **_kwargs) -> list[str]:
+def complete_entity_selector(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
     """Complete entity types for the path-like entity command."""
     model_spec, entity_catalog = get_completion_context(parsed_args)
-    return _filter_matches(_entity_types(model_spec, entity_catalog), prefix)
+    attr_descriptions = {}
+    for etype in _entity_types(model_spec, entity_catalog):
+        if model_spec is not None and etype in model_spec.entities:
+            entity_spec = model_spec.entity(etype)
+            attr_descriptions[etype] = f"{entity_spec.name} ({entity_spec.id_data_type.root} ids)"
+        elif entity_catalog is not None and etype in entity_catalog:
+            entry = entity_catalog[etype]
+            name = entry.get("name") or etype
+            id_data_type = entry.get("id_data_type")
+            if id_data_type:
+                attr_descriptions[etype] = f"{name} ({id_data_type} ids)"
+            else:
+                attr_descriptions[etype] = str(name)
+        else:
+            attr_descriptions[etype] = "Configured entity type."
+    return _match_descriptions(attr_descriptions, prefix)
 
 
-def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> list[str]:  # noqa: PLR0911
+def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:  # noqa: PLR0911
     """Complete type-scope and single-entity commands under `entity`."""
     model_spec, entity_catalog = get_completion_context(parsed_args)
     etype = getattr(parsed_args, "selector", None)
     if etype is None:
-        return []
+        return {}
 
     words = list(getattr(parsed_args, "rest", []))
-    attrs = _entity_attrs(model_spec, etype, entity_catalog)
+    attr_descriptions = _entity_attr_descriptions(model_spec, etype, entity_catalog)
+    attrs = list(attr_descriptions)
     if not words:
-        matches = _filter_matches(ENTITY_TYPE_COMMANDS, prefix)
+        matches = _match_descriptions(TYPE_COMMAND_DESCRIPTIONS, prefix)
         if not prefix or not prefix.startswith("-"):
-            matches.append(ENTITY_ID_PLACEHOLDER)
+            matches[ENTITY_ID_PLACEHOLDER] = "Enter an entity id to inspect one entity."
         return matches
 
     command = words[0]
@@ -228,68 +318,104 @@ def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> list[str]:  # n
             args,
             prefix,
             options=TYPE_LIST_OPTIONS,
+            option_descriptions=TYPE_OPTION_DESCRIPTIONS,
             value_choices={"--has-attr": attrs},
+            value_descriptions={"--has-attr": attr_descriptions},
         )
     if command == "count":
         return _complete_options(
             args,
             prefix,
             options=TYPE_COUNT_OPTIONS,
+            option_descriptions=TYPE_OPTION_DESCRIPTIONS,
             value_choices={"--has-attr": attrs},
+            value_descriptions={"--has-attr": attr_descriptions},
         )
     if command == "raw":
         return _complete_options(
             args,
             prefix,
             options=RAW_OPTIONS,
+            option_descriptions=RAW_OPTION_DESCRIPTIONS,
             value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
+            value_descriptions={
+                "--attr": attr_descriptions,
+                "--format": VALUE_CHOICE_DESCRIPTIONS,
+            },
         )
     if command == "attr":
         if not args:
-            return _filter_matches(attrs, prefix)
+            return _match_descriptions(attr_descriptions, prefix)
         if len(args) == 1:
-            return _filter_matches(["distinct"], prefix)
-        return []
+            return _match_descriptions(
+                {"distinct": "Get distinct latest values of this attribute."}, prefix
+            )
+        return {}
     if command in ENTITY_TYPE_COMMANDS:
-        return _filter_matches(ENTITY_TYPE_COMMANDS, prefix)
+        return _match_descriptions(TYPE_COMMAND_DESCRIPTIONS, prefix)
 
     if not args:
-        return _filter_matches(ENTITY_INSTANCE_COMMANDS, prefix)
+        return _match_descriptions(INSTANCE_COMMAND_DESCRIPTIONS, prefix)
 
     entity_command = args[0]
     entity_args = args[1:]
     if entity_command in {"get", "master"}:
-        return _complete_options(entity_args, prefix, options=TIME_RANGE_OPTIONS)
+        return _complete_options(
+            entity_args,
+            prefix,
+            options=TIME_RANGE_OPTIONS,
+            option_descriptions=TIME_RANGE_OPTION_DESCRIPTIONS,
+        )
     if entity_command == "snapshots":
         return _complete_options(
             entity_args,
             prefix,
             options=SNAPSHOT_OPTIONS,
+            option_descriptions=SNAPSHOT_OPTION_DESCRIPTIONS,
             value_choices={"--format": ["json", "ndjson"]},
+            value_descriptions={"--format": VALUE_CHOICE_DESCRIPTIONS},
         )
     if entity_command == "raw":
         return _complete_options(
             entity_args,
             prefix,
             options=RAW_OPTIONS,
+            option_descriptions=RAW_OPTION_DESCRIPTIONS,
             value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
+            value_descriptions={
+                "--attr": attr_descriptions,
+                "--format": VALUE_CHOICE_DESCRIPTIONS,
+            },
         )
     if entity_command == "ttl":
-        return _filter_matches(["--body-json"], prefix)
+        return _match_descriptions(
+            {"--body-json": "JSON body describing the TTL update request."}, prefix
+        )
     if entity_command == "delete":
-        return []
+        return {}
     if entity_command == "attr":
         if not entity_args:
-            return _filter_matches(attrs, prefix)
+            return _match_descriptions(attr_descriptions, prefix)
         attr = entity_args[0]
         attr_args = entity_args[1:]
         if not attr_args:
-            return _filter_matches(["get", "set"], prefix)
+            return _match_descriptions(
+                {
+                    "get": "Get the current value of this attribute.",
+                    "set": "Set the current value of this attribute.",
+                },
+                prefix,
+            )
         if attr_args[0] == "get":
-            return _complete_options(attr_args[1:], prefix, options=TIME_RANGE_OPTIONS)
+            return _complete_options(
+                attr_args[1:],
+                prefix,
+                options=TIME_RANGE_OPTIONS,
+                option_descriptions=TIME_RANGE_OPTION_DESCRIPTIONS,
+            )
         if attr_args[0] == "set":
-            return []
+            return {}
         if attr.startswith(prefix):
-            return [attr]
-        return []
-    return _filter_matches(ENTITY_INSTANCE_COMMANDS, prefix)
+            return {attr: attr_descriptions.get(attr, f"Attribute on entity type '{etype}'.")}
+        return {}
+    return _match_descriptions(INSTANCE_COMMAND_DESCRIPTIONS, prefix)

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -85,7 +85,7 @@ def add_ndjson_format_arg(parser: argparse.ArgumentParser) -> None:
         "-F",
         "--format",
         choices=["json", "ndjson"],
-        default="json",
+        default="ndjson",
         help="Choose JSON or NDJSON output.",
     )
 

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -23,7 +23,7 @@ RAW_HELP = (
     "Can be slow on large raw collections."
 )
 ATTR_VALUE_HELP = "JSON literal value, for example '\"hello\"', '42', 'true', or '{\"k\":1}'."
-ENTITY_TYPE_COMMANDS = ["list", "count", "raw", "attr"]
+ENTITY_TYPE_COMMANDS = ["list", "count", "raw", "attr-values"]
 ENTITY_INSTANCE_COMMANDS = ["get", "master", "snapshots", "raw", "ttl", "delete", "attr"]
 ENTITY_ID_PLACEHOLDER = "<EID>"
 TYPE_LIST_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr", "--skip", "--limit"]
@@ -35,7 +35,7 @@ TYPE_COMMAND_DESCRIPTIONS = {
     "list": "List latest entity snapshots for the entity type.",
     "count": "Count latest entity snapshots for the entity type.",
     "raw": RAW_HELP,
-    "attr": "Query one attribute across the entity type.",
+    "attr-values": "Get distinct latest values of one attribute across the entity type.",
 }
 INSTANCE_COMMAND_DESCRIPTIONS = {
     "get": "Get the combined entity view.",
@@ -343,13 +343,9 @@ def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
                 "--format": VALUE_CHOICE_DESCRIPTIONS,
             },
         )
-    if command == "attr":
+    if command == "attr-values":
         if not args:
             return _match_descriptions(attr_descriptions, prefix)
-        if len(args) == 1:
-            return _match_descriptions(
-                {"distinct": "Get distinct latest values of this attribute."}, prefix
-            )
         return {}
     if command in ENTITY_TYPE_COMMANDS:
         return _match_descriptions(TYPE_COMMAND_DESCRIPTIONS, prefix)

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -3,12 +3,14 @@
 
 import argparse
 import json
+from collections.abc import Iterable, Sequence
 from typing import Any, Optional
 
 from dp3.bin.shcmd.common import (
     JSON_LITERAL_HELP,
     APIError,
     common_time_params,
+    get_completion_context,
     print_response_json,
     read_json_object,
     read_json_value,
@@ -21,6 +23,14 @@ RAW_HELP = (
     "Can be slow on large raw collections."
 )
 ATTR_VALUE_HELP = "JSON literal value, for example '\"hello\"', '42', 'true', or '{\"k\":1}'."
+ENTITY_TYPE_COMMANDS = ["list", "count", "raw", "attr"]
+ENTITY_INSTANCE_COMMANDS = ["get", "master", "snapshots", "raw", "ttl", "delete", "attr"]
+ENTITY_ID_PLACEHOLDER = "<EID>"
+TYPE_LIST_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr", "--skip", "--limit"]
+TYPE_COUNT_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr"]
+RAW_OPTIONS = ["--attr", "--src", "--skip", "--limit", "--format"]
+TIME_RANGE_OPTIONS = ["--from", "--to"]
+SNAPSHOT_OPTIONS = ["--from", "--to", "--skip", "--limit", "--format"]
 
 
 def add_time_range_args(parser: argparse.ArgumentParser) -> None:
@@ -153,3 +163,133 @@ def build_time_page_params(args) -> dict[str, Any]:
     params["skip"] = args.skip
     params["limit"] = args.limit
     return params
+
+
+def _filter_matches(values: Iterable[str], prefix: str) -> list[str]:
+    return [value for value in values if value.startswith(prefix)]
+
+
+def _entity_types(model_spec, entity_catalog: Optional[dict[str, Any]] = None) -> list[str]:
+    if model_spec is not None:
+        return sorted(model_spec.entities)
+    if entity_catalog is not None:
+        return sorted(entity_catalog)
+    return []
+
+
+def _entity_attrs(
+    model_spec, etype: str, entity_catalog: Optional[dict[str, Any]] = None
+) -> list[str]:
+    if model_spec is not None and etype in model_spec.entities:
+        return sorted(model_spec.attribs(etype))
+    if entity_catalog is not None and etype in entity_catalog:
+        return sorted(entity_catalog[etype].get("attribs", []))
+    return []
+
+
+def _complete_options(
+    args: Sequence[str],
+    prefix: str,
+    *,
+    options: Sequence[str],
+    value_choices: Optional[dict[str, Sequence[str]]] = None,
+) -> list[str]:
+    value_choices = value_choices or {}
+    if args and args[-1] in value_choices:
+        return _filter_matches(value_choices[args[-1]], prefix)
+    return _filter_matches(options, prefix)
+
+
+def complete_entity_selector(prefix: str, parsed_args, **_kwargs) -> list[str]:
+    """Complete entity types for the path-like entity command."""
+    model_spec, entity_catalog = get_completion_context(parsed_args)
+    return _filter_matches(_entity_types(model_spec, entity_catalog), prefix)
+
+
+def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> list[str]:  # noqa: PLR0911
+    """Complete type-scope and single-entity commands under `entity`."""
+    model_spec, entity_catalog = get_completion_context(parsed_args)
+    etype = getattr(parsed_args, "selector", None)
+    if etype is None:
+        return []
+
+    words = list(getattr(parsed_args, "rest", []))
+    attrs = _entity_attrs(model_spec, etype, entity_catalog)
+    if not words:
+        matches = _filter_matches(ENTITY_TYPE_COMMANDS, prefix)
+        if not prefix or not prefix.startswith("-"):
+            matches.append(ENTITY_ID_PLACEHOLDER)
+        return matches
+
+    command = words[0]
+    args = words[1:]
+    if command == "list":
+        return _complete_options(
+            args,
+            prefix,
+            options=TYPE_LIST_OPTIONS,
+            value_choices={"--has-attr": attrs},
+        )
+    if command == "count":
+        return _complete_options(
+            args,
+            prefix,
+            options=TYPE_COUNT_OPTIONS,
+            value_choices={"--has-attr": attrs},
+        )
+    if command == "raw":
+        return _complete_options(
+            args,
+            prefix,
+            options=RAW_OPTIONS,
+            value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
+        )
+    if command == "attr":
+        if not args:
+            return _filter_matches(attrs, prefix)
+        if len(args) == 1:
+            return _filter_matches(["distinct"], prefix)
+        return []
+    if command in ENTITY_TYPE_COMMANDS:
+        return _filter_matches(ENTITY_TYPE_COMMANDS, prefix)
+
+    if not args:
+        return _filter_matches(ENTITY_INSTANCE_COMMANDS, prefix)
+
+    entity_command = args[0]
+    entity_args = args[1:]
+    if entity_command in {"get", "master"}:
+        return _complete_options(entity_args, prefix, options=TIME_RANGE_OPTIONS)
+    if entity_command == "snapshots":
+        return _complete_options(
+            entity_args,
+            prefix,
+            options=SNAPSHOT_OPTIONS,
+            value_choices={"--format": ["json", "ndjson"]},
+        )
+    if entity_command == "raw":
+        return _complete_options(
+            entity_args,
+            prefix,
+            options=RAW_OPTIONS,
+            value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
+        )
+    if entity_command == "ttl":
+        return _filter_matches(["--body-json"], prefix)
+    if entity_command == "delete":
+        return []
+    if entity_command == "attr":
+        if not entity_args:
+            return _filter_matches(attrs, prefix)
+        attr = entity_args[0]
+        attr_args = entity_args[1:]
+        if not attr_args:
+            return _filter_matches(["get", "set"], prefix)
+        if attr_args[0] == "get":
+            return _complete_options(attr_args[1:], prefix, options=TIME_RANGE_OPTIONS)
+        if attr_args[0] == "set":
+            return []
+        if attr.startswith(prefix):
+            return [attr]
+        return []
+    return _filter_matches(ENTITY_INSTANCE_COMMANDS, prefix)

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -3,8 +3,9 @@
 
 import argparse
 import json
-from collections.abc import Iterable, Sequence
 from typing import Any, Optional
+
+from argcomplete.finders import CompletionFinder
 
 from dp3.bin.shcmd.common import (
     JSON_LITERAL_HELP,
@@ -23,81 +24,76 @@ RAW_HELP = (
     "Can be slow on large raw collections."
 )
 ATTR_VALUE_HELP = "JSON literal value, for example '\"hello\"', '42', 'true', or '{\"k\":1}'."
-ENTITY_TYPE_COMMANDS = ["list", "count", "raw", "attr-values"]
-ENTITY_INSTANCE_COMMANDS = ["get", "master", "snapshots", "raw", "ttl", "delete", "attr"]
 ENTITY_ID_PLACEHOLDER = "<EID>"
-TYPE_LIST_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr", "--skip", "--limit"]
-TYPE_COUNT_OPTIONS = ["--fulltext-json", "--filter-json", "--has-attr"]
-RAW_OPTIONS = ["--attr", "--src", "--skip", "--limit", "--format"]
-TIME_RANGE_OPTIONS = ["--from", "--to"]
-SNAPSHOT_OPTIONS = ["--from", "--to", "--skip", "--limit", "--format"]
-TYPE_COMMAND_DESCRIPTIONS = {
-    "list": "List latest entity snapshots for the entity type.",
-    "count": "Count latest entity snapshots for the entity type.",
-    "raw": RAW_HELP,
-    "attr-values": "Get distinct latest values of one attribute across the entity type.",
-}
-INSTANCE_COMMAND_DESCRIPTIONS = {
-    "get": "Get the combined entity view.",
-    "master": "Get the current master record.",
-    "snapshots": "Browse snapshots of a single entity.",
-    "raw": RAW_HELP,
-    "ttl": "Extend TTL values for the entity.",
-    "delete": "Delete the entity data.",
-    "attr": "Get or modify one entity attribute.",
-}
-TYPE_OPTION_DESCRIPTIONS = {
-    "--fulltext-json": "JSON object with fulltext search filters.",
-    "--filter-json": "JSON object with additional generic filters.",
-    "--has-attr": "Limit results to entities where the attribute has data present.",
-    "--skip": "Skip this many results before returning data.",
-    "--limit": "Return at most this many results.",
-}
-RAW_OPTION_DESCRIPTIONS = {
-    "--attr": "Limit raw datapoints to one attribute.",
-    "--src": "Limit raw datapoints to one source.",
-    "--skip": "Skip this many raw datapoints before returning data.",
-    "--limit": "Return at most this many raw datapoints.",
-    "--format": "Choose JSON or NDJSON output.",
-}
-TIME_RANGE_OPTION_DESCRIPTIONS = {
-    "--from": "Lower bound of the time range.",
-    "--to": "Upper bound of the time range.",
-}
-SNAPSHOT_OPTION_DESCRIPTIONS = {
-    "--from": "Lower bound of the snapshot time range.",
-    "--to": "Upper bound of the snapshot time range.",
-    "--skip": "Skip this many snapshots before returning data.",
-    "--limit": "Return at most this many snapshots.",
-    "--format": "Choose JSON or NDJSON output.",
-}
-VALUE_CHOICE_DESCRIPTIONS = {
-    "json": "Return structured JSON output.",
-    "ndjson": "Return newline-delimited JSON output.",
-}
 
 
-def add_time_range_args(parser: argparse.ArgumentParser) -> None:
+def suppress_completion(_prefix: str, **_kwargs) -> dict[str, str]:
+    """Return no completion candidates for free-form values."""
+    return {}
+
+
+def add_time_range_args(
+    parser: argparse.ArgumentParser,
+    *,
+    scope: str = "time range",
+) -> None:
     """Add common time-range arguments to a parser."""
-    parser.add_argument("--from", dest="date_from")
-    parser.add_argument("--to", dest="date_to")
+    from_action = parser.add_argument(
+        "--from",
+        dest="date_from",
+        help=f"Lower bound of the {scope}.",
+    )
+    from_action.completer = suppress_completion
+    to_action = parser.add_argument(
+        "--to",
+        dest="date_to",
+        help=f"Upper bound of the {scope}.",
+    )
+    to_action.completer = suppress_completion
 
 
-def add_page_args(parser: argparse.ArgumentParser, *, default_limit: int) -> None:
+def add_page_args(
+    parser: argparse.ArgumentParser,
+    *,
+    default_limit: int,
+    subject: str = "results",
+) -> None:
     """Add common paging arguments to a parser."""
-    parser.add_argument("--skip", type=int, default=0)
-    parser.add_argument("--limit", type=int, default=default_limit)
+    skip_action = parser.add_argument(
+        "--skip",
+        type=int,
+        default=0,
+        help=f"Skip this many {subject} before returning data.",
+    )
+    skip_action.completer = suppress_completion
+    limit_action = parser.add_argument(
+        "--limit",
+        type=int,
+        default=default_limit,
+        help=f"Return at most this many {subject}.",
+    )
+    limit_action.completer = suppress_completion
 
 
 def add_ndjson_format_arg(parser: argparse.ArgumentParser) -> None:
     """Add common JSON/NDJSON output selection."""
-    parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    parser.add_argument(
+        "--format",
+        choices=["json", "ndjson"],
+        default="json",
+        help="Choose JSON or NDJSON output.",
+    )
 
 
 def add_raw_filter_args(parser: argparse.ArgumentParser) -> None:
     """Add common raw datapoint filters to a parser."""
-    parser.add_argument("--attr")
-    parser.add_argument("--src")
+    attr_action = parser.add_argument(
+        "--attr",
+        help="Limit raw datapoints to one attribute.",
+    )
+    attr_action.completer = complete_entity_attr_names
+    src_action = parser.add_argument("--src", help="Limit raw datapoints to one source.")
+    src_action.completer = suppress_completion
 
 
 def add_type_filter_args(
@@ -107,13 +103,24 @@ def add_type_filter_args(
     default_limit: int = 20,
 ) -> None:
     """Add common entity-type filters to a parser."""
-    parser.add_argument("--fulltext-json", default=None)
-    parser.add_argument("--filter-json", default=None)
-    parser.add_argument(
+    fulltext_action = parser.add_argument(
+        "--fulltext-json",
+        default=None,
+        help="JSON object with fulltext search filters.",
+    )
+    fulltext_action.completer = suppress_completion
+    filter_action = parser.add_argument(
+        "--filter-json",
+        default=None,
+        help="JSON object with additional generic filters.",
+    )
+    filter_action.completer = suppress_completion
+    has_attr_action = parser.add_argument(
         "--has-attr",
         default=None,
         help="Limit results to latest snapshots where the attribute has data present.",
     )
+    has_attr_action.completer = complete_entity_attr_names
     if include_paging:
         add_page_args(parser, default_limit=default_limit)
 
@@ -197,8 +204,14 @@ def handle_attr_set_request(client, args) -> int:
 
 def add_entity_attr_set_args(parser: argparse.ArgumentParser) -> None:
     """Add the value argument for entity attribute updates."""
-    parser.add_argument("value_json", metavar="VALUE_JSON", help=ATTR_VALUE_HELP)
-    parser.add_argument("--value-json", dest="value_json_flag", help=argparse.SUPPRESS)
+    value_action = parser.add_argument("value_json", metavar="VALUE_JSON", help=ATTR_VALUE_HELP)
+    value_action.completer = suppress_completion
+    value_flag_action = parser.add_argument(
+        "--value-json",
+        dest="value_json_flag",
+        help=argparse.SUPPRESS,
+    )
+    value_flag_action.completer = suppress_completion
 
 
 def build_time_page_params(args) -> dict[str, Any]:
@@ -207,10 +220,6 @@ def build_time_page_params(args) -> dict[str, Any]:
     params["skip"] = args.skip
     params["limit"] = args.limit
     return params
-
-
-def _filter_matches(values: Iterable[str], prefix: str) -> list[str]:
-    return [value for value in values if value.startswith(prefix)]
 
 
 def _match_descriptions(values: dict[str, str], prefix: str) -> dict[str, str]:
@@ -247,30 +256,27 @@ def _entity_attr_descriptions(
     return descriptions
 
 
-def _complete_options(
-    args: Sequence[str],
+def _normalize_completion(value: str) -> str:
+    return value.rstrip()
+
+
+def _complete_from_parser(
+    parser: argparse.ArgumentParser,
+    words: list[str],
     prefix: str,
-    *,
-    options: Sequence[str],
-    option_descriptions: Optional[dict[str, str]] = None,
-    value_choices: Optional[dict[str, Sequence[str]]] = None,
-    value_descriptions: Optional[dict[str, dict[str, str]]] = None,
+    parsed_args,
 ) -> dict[str, str]:
-    option_descriptions = option_descriptions or {}
-    value_choices = value_choices or {}
-    value_descriptions = value_descriptions or {}
-    if args and args[-1] in value_choices:
-        choices = value_choices[args[-1]]
-        descriptions = value_descriptions.get(args[-1], {})
-        return {
-            choice: descriptions.get(choice, f"Value for {args[-1]}.")
-            for choice in choices
-            if choice.startswith(prefix)
-        }
+    parser.set_defaults(
+        config=getattr(parsed_args, "config", None),
+        url=getattr(parsed_args, "url", None),
+        timeout=getattr(parsed_args, "timeout", 5.0),
+    )
+    finder = CompletionFinder(parser, always_complete_options=False)
+    values = finder._get_completions([parser.prog, *words], prefix, "", None)
+    descriptions = getattr(finder, "_display_completions", {})
     return {
-        option: option_descriptions.get(option, "Command option.")
-        for option in options
-        if option.startswith(prefix)
+        _normalize_completion(value): descriptions.get(_normalize_completion(value), "")
+        for value in values
     }
 
 
@@ -295,123 +301,33 @@ def complete_entity_selector(prefix: str, parsed_args, **_kwargs) -> dict[str, s
     return _match_descriptions(attr_descriptions, prefix)
 
 
-def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:  # noqa: PLR0911
-    """Complete type-scope and single-entity commands under `entity`."""
+def complete_entity_attr_names(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
+    """Complete attribute names for one entity type."""
+    etype = getattr(parsed_args, "etype", None) or getattr(parsed_args, "selector", None)
+    if etype is None:
+        return {}
     model_spec, entity_catalog = get_completion_context(parsed_args)
+    return _match_descriptions(_entity_attr_descriptions(model_spec, etype, entity_catalog), prefix)
+
+
+def complete_entity_rest(prefix: str, parsed_args, **_kwargs) -> dict[str, str]:
+    """Complete type-scope and single-entity commands under `entity`."""
     etype = getattr(parsed_args, "selector", None)
     if etype is None:
         return {}
 
+    from . import etype as entity_etype
+    from . import instance as entity_instance
+
     words = list(getattr(parsed_args, "rest", []))
-    attr_descriptions = _entity_attr_descriptions(model_spec, etype, entity_catalog)
-    attrs = list(attr_descriptions)
+    type_parser = entity_etype.build_parser(etype)
     if not words:
-        matches = _match_descriptions(TYPE_COMMAND_DESCRIPTIONS, prefix)
+        matches = _complete_from_parser(type_parser, [], prefix, parsed_args)
         if not prefix or not prefix.startswith("-"):
             matches[ENTITY_ID_PLACEHOLDER] = "Enter an entity id to inspect one entity."
         return matches
+    if words[0] in entity_etype.TYPE_COMMANDS:
+        return _complete_from_parser(type_parser, words, prefix, parsed_args)
 
-    command = words[0]
-    args = words[1:]
-    if command == "list":
-        return _complete_options(
-            args,
-            prefix,
-            options=TYPE_LIST_OPTIONS,
-            option_descriptions=TYPE_OPTION_DESCRIPTIONS,
-            value_choices={"--has-attr": attrs},
-            value_descriptions={"--has-attr": attr_descriptions},
-        )
-    if command == "count":
-        return _complete_options(
-            args,
-            prefix,
-            options=TYPE_COUNT_OPTIONS,
-            option_descriptions=TYPE_OPTION_DESCRIPTIONS,
-            value_choices={"--has-attr": attrs},
-            value_descriptions={"--has-attr": attr_descriptions},
-        )
-    if command == "raw":
-        return _complete_options(
-            args,
-            prefix,
-            options=RAW_OPTIONS,
-            option_descriptions=RAW_OPTION_DESCRIPTIONS,
-            value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
-            value_descriptions={
-                "--attr": attr_descriptions,
-                "--format": VALUE_CHOICE_DESCRIPTIONS,
-            },
-        )
-    if command == "attr-values":
-        if not args:
-            return _match_descriptions(attr_descriptions, prefix)
-        return {}
-    if command in ENTITY_TYPE_COMMANDS:
-        return _match_descriptions(TYPE_COMMAND_DESCRIPTIONS, prefix)
-
-    if not args:
-        return _match_descriptions(INSTANCE_COMMAND_DESCRIPTIONS, prefix)
-
-    entity_command = args[0]
-    entity_args = args[1:]
-    if entity_command in {"get", "master"}:
-        return _complete_options(
-            entity_args,
-            prefix,
-            options=TIME_RANGE_OPTIONS,
-            option_descriptions=TIME_RANGE_OPTION_DESCRIPTIONS,
-        )
-    if entity_command == "snapshots":
-        return _complete_options(
-            entity_args,
-            prefix,
-            options=SNAPSHOT_OPTIONS,
-            option_descriptions=SNAPSHOT_OPTION_DESCRIPTIONS,
-            value_choices={"--format": ["json", "ndjson"]},
-            value_descriptions={"--format": VALUE_CHOICE_DESCRIPTIONS},
-        )
-    if entity_command == "raw":
-        return _complete_options(
-            entity_args,
-            prefix,
-            options=RAW_OPTIONS,
-            option_descriptions=RAW_OPTION_DESCRIPTIONS,
-            value_choices={"--attr": attrs, "--format": ["json", "ndjson"]},
-            value_descriptions={
-                "--attr": attr_descriptions,
-                "--format": VALUE_CHOICE_DESCRIPTIONS,
-            },
-        )
-    if entity_command == "ttl":
-        return _match_descriptions(
-            {"--body-json": "JSON body describing the TTL update request."}, prefix
-        )
-    if entity_command == "delete":
-        return {}
-    if entity_command == "attr":
-        if not entity_args:
-            return _match_descriptions(attr_descriptions, prefix)
-        attr = entity_args[0]
-        attr_args = entity_args[1:]
-        if not attr_args:
-            return _match_descriptions(
-                {
-                    "get": "Get the current value of this attribute.",
-                    "set": "Set the current value of this attribute.",
-                },
-                prefix,
-            )
-        if attr_args[0] == "get":
-            return _complete_options(
-                attr_args[1:],
-                prefix,
-                options=TIME_RANGE_OPTIONS,
-                option_descriptions=TIME_RANGE_OPTION_DESCRIPTIONS,
-            )
-        if attr_args[0] == "set":
-            return {}
-        if attr.startswith(prefix):
-            return {attr: attr_descriptions.get(attr, f"Attribute on entity type '{etype}'.")}
-        return {}
-    return _match_descriptions(INSTANCE_COMMAND_DESCRIPTIONS, prefix)
+    instance_parser = entity_instance.build_parser(etype, words[0])
+    return _complete_from_parser(instance_parser, words[1:], prefix, parsed_args)

--- a/dp3/bin/shcmd/entity/common.py
+++ b/dp3/bin/shcmd/entity/common.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Shared helpers for entity commands in the shell-oriented DP3 CLI."""
+
+import argparse
+import json
+from typing import Any, Optional
+
+from dp3.bin.shcmd.common import (
+    JSON_LITERAL_HELP,
+    APIError,
+    common_time_params,
+    print_response_json,
+    read_json_object,
+    read_json_value,
+    stream_json_pages,
+)
+from dp3.common.attrspec import AttrType
+
+RAW_HELP = (
+    "Browse current raw datapoints for troubleshooting ingestion. "
+    "Can be slow on large raw collections."
+)
+ATTR_VALUE_HELP = "JSON literal value, for example '\"hello\"', '42', 'true', or '{\"k\":1}'."
+
+
+def add_time_range_args(parser: argparse.ArgumentParser) -> None:
+    """Add common time-range arguments to a parser."""
+    parser.add_argument("--from", dest="date_from")
+    parser.add_argument("--to", dest="date_to")
+
+
+def add_page_args(parser: argparse.ArgumentParser, *, default_limit: int) -> None:
+    """Add common paging arguments to a parser."""
+    parser.add_argument("--skip", type=int, default=0)
+    parser.add_argument("--limit", type=int, default=default_limit)
+
+
+def add_ndjson_format_arg(parser: argparse.ArgumentParser) -> None:
+    """Add common JSON/NDJSON output selection."""
+    parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+
+
+def add_raw_filter_args(parser: argparse.ArgumentParser) -> None:
+    """Add common raw datapoint filters to a parser."""
+    parser.add_argument("--attr")
+    parser.add_argument("--src")
+
+
+def add_type_filter_args(
+    parser: argparse.ArgumentParser,
+    *,
+    include_paging: bool,
+    default_limit: int = 20,
+) -> None:
+    """Add common entity-type filters to a parser."""
+    parser.add_argument("--fulltext-json", default=None)
+    parser.add_argument("--filter-json", default=None)
+    parser.add_argument(
+        "--has-attr",
+        default=None,
+        help="Limit results to latest snapshots where the attribute has data present.",
+    )
+    if include_paging:
+        add_page_args(parser, default_limit=default_limit)
+
+
+def build_has_attr_filter(client, etype: str, attr: str) -> dict[str, Any]:
+    """Build a generic-filter clause for entities with data present for one attribute."""
+    if client.model_spec is None:
+        raise APIError("Attribute-presence filtering requires a readable model specification.")
+    if etype not in client.model_spec.entities:
+        raise APIError(f"Unknown entity type '{etype}'.")
+    if attr not in client.model_spec.attribs(etype):
+        raise APIError(f"Attribute '{attr}' doesn't exist on entity type '{etype}'.")
+
+    query = {f"last.{attr}": {"$exists": True}}
+    attr_spec = client.model_spec.attr(etype, attr)
+    if attr_spec.t in AttrType.TIMESERIES | AttrType.OBSERVATIONS:
+        query[f"last.{attr}"]["$ne"] = []
+    return query
+
+
+def build_generic_filter_param(client, args) -> Optional[str]:
+    """Build the generic-filter query parameter for entity type queries."""
+    query = None
+    if getattr(args, "filter_json", None) is not None:
+        query = read_json_object(args.filter_json, "--filter-json")
+    if getattr(args, "has_attr", None) is not None:
+        has_attr_filter = build_has_attr_filter(client, args.etype, args.has_attr)
+        query = has_attr_filter if query is None else {"$and": [query, has_attr_filter]}
+    if query is None:
+        return None
+    return json.dumps(query)
+
+
+def build_type_query_params(client, args, *, include_paging: bool) -> dict[str, Any]:
+    """Build query parameters shared by list and count operations."""
+    params = {}
+    if include_paging:
+        params.update({"skip": args.skip, "limit": args.limit})
+    if args.fulltext_json is not None:
+        params["fulltext_filters"] = args.fulltext_json
+    generic_filter = build_generic_filter_param(client, args)
+    if generic_filter is not None:
+        params["generic_filter"] = generic_filter
+    return params
+
+
+def build_raw_params(args) -> dict[str, Any]:
+    """Build raw-datapoint query parameters."""
+    params = {"skip": args.skip, "limit": args.limit}
+    if getattr(args, "eid", None) is not None:
+        params["eid"] = args.eid
+    if args.attr is not None:
+        params["attr"] = args.attr
+    if args.src is not None:
+        params["src"] = args.src
+    return params
+
+
+def handle_raw(client, args) -> int:
+    """Browse current raw datapoints for one type or one entity."""
+    params = build_raw_params(args)
+    path = f"/entity/{args.etype}/raw/get"
+    if args.format == "ndjson":
+        base_params = {key: value for key, value in params.items() if key not in {"skip", "limit"}}
+        return stream_json_pages(client, path, base_params, args.skip, args.limit)
+    return print_response_json(client.request("GET", path, params=params))
+
+
+def handle_attr_set_request(client, args) -> int:
+    """Set one current entity attribute value."""
+    value_json = args.value_json
+    if value_json is None:
+        value_json = getattr(args, "value_json_flag", None)
+    if value_json is None:
+        raise APIError(JSON_LITERAL_HELP)
+    body = {"value": read_json_value(value_json)}
+    return print_response_json(
+        client.request("POST", f"/entity/{args.etype}/{args.eid}/set/{args.attr}", json_body=body)
+    )
+
+
+def add_entity_attr_set_args(parser: argparse.ArgumentParser) -> None:
+    """Add the value argument for entity attribute updates."""
+    parser.add_argument("value_json", metavar="VALUE_JSON", help=ATTR_VALUE_HELP)
+    parser.add_argument("--value-json", dest="value_json_flag", help=argparse.SUPPRESS)
+
+
+def build_time_page_params(args) -> dict[str, Any]:
+    """Build query parameters for time-ranged, paged entity resources."""
+    params = common_time_params(args)
+    params["skip"] = args.skip
+    params["limit"] = args.limit
+    return params

--- a/dp3/bin/shcmd/entity/etype.py
+++ b/dp3/bin/shcmd/entity/etype.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-from dp3.bin.shcmd.common import print_response_json
+from dp3.bin.shcmd.common import print_response_json, stream_json_pages
 
 from . import instance
 from .common import (
@@ -20,8 +20,12 @@ from .common import (
 
 def handle_list(client, args) -> int:
     """List latest entity snapshots for one type."""
+    path = f"/entity/{args.etype}/get"
     params = build_type_query_params(client, args, include_paging=True)
-    return print_response_json(client.request("GET", f"/entity/{args.etype}/get", params=params))
+    if args.format == "ndjson":
+        base_params = {key: value for key, value in params.items() if key not in {"skip", "limit"}}
+        return stream_json_pages(client, path, base_params, args.skip, args.limit)
+    return print_response_json(client.request("GET", path, params=params))
 
 
 def handle_count(client, args) -> int:
@@ -48,6 +52,7 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
 
     list_parser = commands.add_parser("list", help="List latest entity snapshots.")
     add_type_filter_args(list_parser, include_paging=True)
+    add_ndjson_format_arg(list_parser)
     list_parser.set_defaults(handler=handle_list, etype=etype)
 
     count_parser = commands.add_parser("count", help="Count latest entity snapshots.")

--- a/dp3/bin/shcmd/entity/etype.py
+++ b/dp3/bin/shcmd/entity/etype.py
@@ -5,6 +5,7 @@ import argparse
 
 from dp3.bin.shcmd.common import print_response_json
 
+from . import instance
 from .common import (
     RAW_HELP,
     add_ndjson_format_arg,
@@ -15,8 +16,6 @@ from .common import (
     complete_entity_attr_names,
     handle_raw,
 )
-
-TYPE_COMMANDS = {"list", "count", "raw", "attr-values", "-h", "--help"}
 
 
 def handle_list(client, args) -> int:
@@ -42,9 +41,7 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
     """Build the parser for entity type-scope commands."""
     parser = argparse.ArgumentParser(
         prog=f"dp3 sh entity {etype}",
-        description=(
-            f"Query entities of type '{etype}' or continue with an entity id to inspect one entity."
-        ),
+        description=(f"Query entities of type '{etype}' or use 'id' to inspect one entity by id."),
     )
     parser.set_defaults(etype=etype)
     commands = parser.add_subparsers(dest="entity_type_command", required=True)
@@ -73,5 +70,7 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
     )
     attr_action.completer = complete_entity_attr_names
     attr_values_parser.set_defaults(handler=handle_distinct, etype=etype)
+
+    instance.add_id_parser(commands, etype)
 
     return parser

--- a/dp3/bin/shcmd/entity/etype.py
+++ b/dp3/bin/shcmd/entity/etype.py
@@ -15,7 +15,7 @@ from .common import (
     handle_raw,
 )
 
-TYPE_COMMANDS = {"list", "count", "raw", "attr", "-h", "--help"}
+TYPE_COMMANDS = {"list", "count", "raw", "attr-values", "-h", "--help"}
 
 
 def handle_list(client, args) -> int:
@@ -61,14 +61,14 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
     add_ndjson_format_arg(raw_parser)
     raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=None)
 
-    attr_parser = commands.add_parser(
-        "attr", help="Query a single attribute across the entity type."
+    attr_values_parser = commands.add_parser(
+        "attr-values",
+        help="Get distinct latest values of one attribute across the entity type.",
+        description="Get distinct latest values of one attribute across the entity type.",
     )
-    attr_parser.add_argument("attr", metavar="ATTR")
-    attr_commands = attr_parser.add_subparsers(dest="entity_type_attr_command", required=True)
-    distinct_parser = attr_commands.add_parser(
-        "distinct", help="Get distinct latest values of an attribute."
+    attr_values_parser.add_argument(
+        "attr", metavar="ATTR", help="Attribute to query across the entity type."
     )
-    distinct_parser.set_defaults(handler=handle_distinct, etype=etype)
+    attr_values_parser.set_defaults(handler=handle_distinct, etype=etype)
 
     return parser

--- a/dp3/bin/shcmd/entity/etype.py
+++ b/dp3/bin/shcmd/entity/etype.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Entity type-scope commands for the shell-oriented DP3 CLI."""
+
+import argparse
+
+from dp3.bin.shcmd.common import print_response_json
+
+from .common import (
+    RAW_HELP,
+    add_ndjson_format_arg,
+    add_page_args,
+    add_raw_filter_args,
+    add_type_filter_args,
+    build_type_query_params,
+    handle_raw,
+)
+
+TYPE_COMMANDS = {"list", "count", "raw", "attr", "-h", "--help"}
+
+
+def handle_list(client, args) -> int:
+    """List latest entity snapshots for one type."""
+    params = build_type_query_params(client, args, include_paging=True)
+    return print_response_json(client.request("GET", f"/entity/{args.etype}/get", params=params))
+
+
+def handle_count(client, args) -> int:
+    """Count latest entity snapshots for one type."""
+    params = build_type_query_params(client, args, include_paging=False)
+    return print_response_json(client.request("GET", f"/entity/{args.etype}/count", params=params))
+
+
+def handle_distinct(client, args) -> int:
+    """Get distinct values for one attribute across an entity type."""
+    return print_response_json(
+        client.request("GET", f"/entity/{args.etype}/_/distinct/{args.attr}")
+    )
+
+
+def build_parser(etype: str) -> argparse.ArgumentParser:
+    """Build the parser for entity type-scope commands."""
+    parser = argparse.ArgumentParser(
+        prog=f"dp3 sh entity {etype}",
+        description=(
+            f"Query entities of type '{etype}' or continue with an entity id to inspect one entity."
+        ),
+    )
+    commands = parser.add_subparsers(dest="entity_type_command", required=True)
+
+    list_parser = commands.add_parser("list", help="List latest entity snapshots.")
+    add_type_filter_args(list_parser, include_paging=True)
+    list_parser.set_defaults(handler=handle_list, etype=etype)
+
+    count_parser = commands.add_parser("count", help="Count latest entity snapshots.")
+    add_type_filter_args(count_parser, include_paging=False)
+    count_parser.set_defaults(handler=handle_count, etype=etype)
+
+    raw_parser = commands.add_parser("raw", help=RAW_HELP)
+    add_raw_filter_args(raw_parser)
+    add_page_args(raw_parser, default_limit=20)
+    add_ndjson_format_arg(raw_parser)
+    raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=None)
+
+    attr_parser = commands.add_parser(
+        "attr", help="Query a single attribute across the entity type."
+    )
+    attr_parser.add_argument("attr", metavar="ATTR")
+    attr_commands = attr_parser.add_subparsers(dest="entity_type_attr_command", required=True)
+    distinct_parser = attr_commands.add_parser(
+        "distinct", help="Get distinct latest values of an attribute."
+    )
+    distinct_parser.set_defaults(handler=handle_distinct, etype=etype)
+
+    return parser

--- a/dp3/bin/shcmd/entity/etype.py
+++ b/dp3/bin/shcmd/entity/etype.py
@@ -12,6 +12,7 @@ from .common import (
     add_raw_filter_args,
     add_type_filter_args,
     build_type_query_params,
+    complete_entity_attr_names,
     handle_raw,
 )
 
@@ -45,6 +46,7 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
             f"Query entities of type '{etype}' or continue with an entity id to inspect one entity."
         ),
     )
+    parser.set_defaults(etype=etype)
     commands = parser.add_subparsers(dest="entity_type_command", required=True)
 
     list_parser = commands.add_parser("list", help="List latest entity snapshots.")
@@ -57,7 +59,7 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
 
     raw_parser = commands.add_parser("raw", help=RAW_HELP)
     add_raw_filter_args(raw_parser)
-    add_page_args(raw_parser, default_limit=20)
+    add_page_args(raw_parser, default_limit=20, subject="raw datapoints")
     add_ndjson_format_arg(raw_parser)
     raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=None)
 
@@ -66,9 +68,10 @@ def build_parser(etype: str) -> argparse.ArgumentParser:
         help="Get distinct latest values of one attribute across the entity type.",
         description="Get distinct latest values of one attribute across the entity type.",
     )
-    attr_values_parser.add_argument(
+    attr_action = attr_values_parser.add_argument(
         "attr", metavar="ATTR", help="Attribute to query across the entity type."
     )
+    attr_action.completer = complete_entity_attr_names
     attr_values_parser.set_defaults(handler=handle_distinct, etype=etype)
 
     return parser

--- a/dp3/bin/shcmd/entity/instance.py
+++ b/dp3/bin/shcmd/entity/instance.py
@@ -19,6 +19,7 @@ from .common import (
     add_time_range_args,
     build_time_page_params,
     handle_raw,
+    suppress_completion,
 )
 
 
@@ -65,6 +66,7 @@ def build_parser(etype: str, eid: str) -> argparse.ArgumentParser:
         prog=f"dp3 sh entity {etype} {eid}",
         description=f"Inspect or modify entity '{etype}/{eid}'.",
     )
+    parser.set_defaults(etype=etype, eid=eid)
     commands = parser.add_subparsers(dest="entity_instance_command", required=True)
 
     get_parser = commands.add_parser("get", help="Get full entity data.")
@@ -76,21 +78,26 @@ def build_parser(etype: str, eid: str) -> argparse.ArgumentParser:
     master_parser.set_defaults(handler=handle_master, etype=etype, eid=eid)
 
     snapshots_parser = commands.add_parser("snapshots", help="Get snapshots of a single entity.")
-    add_time_range_args(snapshots_parser)
-    add_page_args(snapshots_parser, default_limit=0)
+    add_time_range_args(snapshots_parser, scope="snapshot time range")
+    add_page_args(snapshots_parser, default_limit=0, subject="snapshots")
     add_ndjson_format_arg(snapshots_parser)
     snapshots_parser.set_defaults(handler=handle_snapshots, etype=etype, eid=eid)
 
     raw_parser = commands.add_parser("raw", help=RAW_HELP)
     add_raw_filter_args(raw_parser)
-    add_page_args(raw_parser, default_limit=20)
+    add_page_args(raw_parser, default_limit=20, subject="raw datapoints")
     add_ndjson_format_arg(raw_parser)
     raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=eid)
 
     attr.add_instance_attr_parser(commands, etype, eid)
 
     ttl_parser = commands.add_parser("ttl", help="Extend entity TTLs.")
-    ttl_parser.add_argument("--body-json", required=True)
+    body_action = ttl_parser.add_argument(
+        "--body-json",
+        required=True,
+        help="JSON body describing the TTL update request.",
+    )
+    body_action.completer = suppress_completion
     ttl_parser.set_defaults(handler=handle_ttl, etype=etype, eid=eid)
 
     delete_parser = commands.add_parser("delete", help="Delete entity data.")

--- a/dp3/bin/shcmd/entity/instance.py
+++ b/dp3/bin/shcmd/entity/instance.py
@@ -89,6 +89,7 @@ def _add_instance_commands(parser: argparse.ArgumentParser, etype: str) -> None:
 
     ttl_parser = commands.add_parser("ttl", help="Extend entity TTLs.")
     body_action = ttl_parser.add_argument(
+        "-b",
         "--body-json",
         required=True,
         help="JSON body describing the TTL update request.",

--- a/dp3/bin/shcmd/entity/instance.py
+++ b/dp3/bin/shcmd/entity/instance.py
@@ -12,6 +12,7 @@ from dp3.bin.shcmd.common import (
 
 from . import attr
 from .common import (
+    ENTITY_ID_PLACEHOLDER,
     RAW_HELP,
     add_ndjson_format_arg,
     add_page_args,
@@ -60,36 +61,31 @@ def handle_delete(client, args) -> int:
     return print_response_json(client.request("DELETE", f"/entity/{args.etype}/{args.eid}"))
 
 
-def build_parser(etype: str, eid: str) -> argparse.ArgumentParser:
-    """Build the parser for single-entity commands."""
-    parser = argparse.ArgumentParser(
-        prog=f"dp3 sh entity {etype} {eid}",
-        description=f"Inspect or modify entity '{etype}/{eid}'.",
-    )
-    parser.set_defaults(etype=etype, eid=eid)
+def _add_instance_commands(parser: argparse.ArgumentParser, etype: str) -> None:
+    """Register single-entity commands under a parser with an `eid` argument."""
     commands = parser.add_subparsers(dest="entity_instance_command", required=True)
 
     get_parser = commands.add_parser("get", help="Get full entity data.")
     add_time_range_args(get_parser)
-    get_parser.set_defaults(handler=handle_get, etype=etype, eid=eid)
+    get_parser.set_defaults(handler=handle_get, etype=etype)
 
     master_parser = commands.add_parser("master", help="Get an entity master record.")
     add_time_range_args(master_parser)
-    master_parser.set_defaults(handler=handle_master, etype=etype, eid=eid)
+    master_parser.set_defaults(handler=handle_master, etype=etype)
 
     snapshots_parser = commands.add_parser("snapshots", help="Get snapshots of a single entity.")
     add_time_range_args(snapshots_parser, scope="snapshot time range")
     add_page_args(snapshots_parser, default_limit=0, subject="snapshots")
     add_ndjson_format_arg(snapshots_parser)
-    snapshots_parser.set_defaults(handler=handle_snapshots, etype=etype, eid=eid)
+    snapshots_parser.set_defaults(handler=handle_snapshots, etype=etype)
 
     raw_parser = commands.add_parser("raw", help=RAW_HELP)
     add_raw_filter_args(raw_parser)
     add_page_args(raw_parser, default_limit=20, subject="raw datapoints")
     add_ndjson_format_arg(raw_parser)
-    raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=eid)
+    raw_parser.set_defaults(handler=handle_raw, etype=etype)
 
-    attr.add_instance_attr_parser(commands, etype, eid)
+    attr.add_instance_attr_parser(commands, etype)
 
     ttl_parser = commands.add_parser("ttl", help="Extend entity TTLs.")
     body_action = ttl_parser.add_argument(
@@ -98,9 +94,27 @@ def build_parser(etype: str, eid: str) -> argparse.ArgumentParser:
         help="JSON body describing the TTL update request.",
     )
     body_action.completer = suppress_completion
-    ttl_parser.set_defaults(handler=handle_ttl, etype=etype, eid=eid)
+    ttl_parser.set_defaults(handler=handle_ttl, etype=etype)
 
     delete_parser = commands.add_parser("delete", help="Delete entity data.")
-    delete_parser.set_defaults(handler=handle_delete, etype=etype, eid=eid)
+    delete_parser.set_defaults(handler=handle_delete, etype=etype)
 
-    return parser
+
+def add_id_parser(commands, etype: str) -> None:
+    """Register the `id` entity selector and nested single-entity commands."""
+    id_parser = commands.add_parser(
+        "id",
+        help="Inspect or modify one entity by id.",
+        description=f"Inspect or modify one entity of type '{etype}' by id.",
+    )
+    id_parser.set_defaults(etype=etype)
+    eid_action = id_parser.add_argument("eid", metavar="EID", help="Entity id.")
+    eid_action.completer = complete_entity_id_placeholder
+    _add_instance_commands(id_parser, etype)
+
+
+def complete_entity_id_placeholder(prefix: str, **_kwargs) -> dict[str, str]:
+    """Suggest the entity-id placeholder in completion output."""
+    if ENTITY_ID_PLACEHOLDER.startswith(prefix):
+        return {ENTITY_ID_PLACEHOLDER: "Enter an entity id to inspect one entity."}
+    return {}

--- a/dp3/bin/shcmd/entity/instance.py
+++ b/dp3/bin/shcmd/entity/instance.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Single-entity commands for the shell-oriented DP3 CLI."""
+
+import argparse
+
+from dp3.bin.shcmd.common import (
+    common_time_params,
+    print_response_json,
+    read_json_value,
+    stream_json_pages,
+)
+
+from . import attr
+from .common import (
+    RAW_HELP,
+    add_ndjson_format_arg,
+    add_page_args,
+    add_raw_filter_args,
+    add_time_range_args,
+    build_time_page_params,
+    handle_raw,
+)
+
+
+def handle_get(client, args) -> int:
+    """Get full entity data."""
+    return print_response_json(
+        client.request("GET", f"/entity/{args.etype}/{args.eid}", params=common_time_params(args))
+    )
+
+
+def handle_master(client, args) -> int:
+    """Get the master record for one entity."""
+    return print_response_json(
+        client.request(
+            "GET", f"/entity/{args.etype}/{args.eid}/master", params=common_time_params(args)
+        )
+    )
+
+
+def handle_snapshots(client, args) -> int:
+    """Get snapshots for one entity."""
+    path = f"/entity/{args.etype}/{args.eid}/snapshots"
+    if args.format == "ndjson":
+        return stream_json_pages(client, path, common_time_params(args), args.skip, args.limit)
+    return print_response_json(client.request("GET", path, params=build_time_page_params(args)))
+
+
+def handle_ttl(client, args) -> int:
+    """Extend entity TTLs."""
+    body = read_json_value(args.body_json)
+    return print_response_json(
+        client.request("POST", f"/entity/{args.etype}/{args.eid}/ttl", json_body=body)
+    )
+
+
+def handle_delete(client, args) -> int:
+    """Delete entity data."""
+    return print_response_json(client.request("DELETE", f"/entity/{args.etype}/{args.eid}"))
+
+
+def build_parser(etype: str, eid: str) -> argparse.ArgumentParser:
+    """Build the parser for single-entity commands."""
+    parser = argparse.ArgumentParser(
+        prog=f"dp3 sh entity {etype} {eid}",
+        description=f"Inspect or modify entity '{etype}/{eid}'.",
+    )
+    commands = parser.add_subparsers(dest="entity_instance_command", required=True)
+
+    get_parser = commands.add_parser("get", help="Get full entity data.")
+    add_time_range_args(get_parser)
+    get_parser.set_defaults(handler=handle_get, etype=etype, eid=eid)
+
+    master_parser = commands.add_parser("master", help="Get an entity master record.")
+    add_time_range_args(master_parser)
+    master_parser.set_defaults(handler=handle_master, etype=etype, eid=eid)
+
+    snapshots_parser = commands.add_parser("snapshots", help="Get snapshots of a single entity.")
+    add_time_range_args(snapshots_parser)
+    add_page_args(snapshots_parser, default_limit=0)
+    add_ndjson_format_arg(snapshots_parser)
+    snapshots_parser.set_defaults(handler=handle_snapshots, etype=etype, eid=eid)
+
+    raw_parser = commands.add_parser("raw", help=RAW_HELP)
+    add_raw_filter_args(raw_parser)
+    add_page_args(raw_parser, default_limit=20)
+    add_ndjson_format_arg(raw_parser)
+    raw_parser.set_defaults(handler=handle_raw, etype=etype, eid=eid)
+
+    attr.add_instance_attr_parser(commands, etype, eid)
+
+    ttl_parser = commands.add_parser("ttl", help="Extend entity TTLs.")
+    ttl_parser.add_argument("--body-json", required=True)
+    ttl_parser.set_defaults(handler=handle_ttl, etype=etype, eid=eid)
+
+    delete_parser = commands.add_parser("delete", help="Delete entity data.")
+    delete_parser.set_defaults(handler=handle_delete, etype=etype, eid=eid)
+
+    return parser

--- a/dp3/bin/shcmd/health.py
+++ b/dp3/bin/shcmd/health.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Health commands for the shell-oriented DP3 CLI."""
+
+from dp3.bin.shcmd.common import print_response_json
+
+
+def handle_health(client, _args) -> int:
+    """Check whether the API root responds successfully."""
+    return print_response_json(client.request("GET", "/"))
+
+
+def register_parser(commands) -> None:
+    """Register health commands on the root parser."""
+    health_parser = commands.add_parser("health", help="Check whether the API is reachable.")
+    health_parser.set_defaults(handler=handle_health)

--- a/dp3/bin/shcmd/telemetry.py
+++ b/dp3/bin/shcmd/telemetry.py
@@ -62,7 +62,12 @@ def register_parser(commands) -> None:
     sources_validity_parser.set_defaults(handler=handle_sources_validity)
 
     source_age_parser = telemetry_commands.add_parser("source-age", help="Show source ages.")
-    source_age_parser.add_argument("--unit", choices=["minutes", "seconds"], default="minutes")
+    source_age_parser.add_argument(
+        "-u",
+        "--unit",
+        choices=["minutes", "seconds"],
+        default="minutes",
+    )
     source_age_parser.set_defaults(handler=handle_source_age)
 
     entities_per_attr_parser = telemetry_commands.add_parser(
@@ -78,13 +83,13 @@ def register_parser(commands) -> None:
     metadata_parser = telemetry_commands.add_parser(
         "metadata", help="Browse internal metadata records."
     )
-    metadata_parser.add_argument("--module")
-    metadata_parser.add_argument("--from", dest="date_from")
-    metadata_parser.add_argument("--to", dest="date_to")
-    metadata_parser.add_argument("--skip", type=int, default=0)
-    metadata_parser.add_argument("--limit", type=int, default=0)
-    metadata_parser.add_argument("--sort", choices=["newest", "oldest"], default="newest")
-    metadata_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    metadata_parser.add_argument("-m", "--module")
+    metadata_parser.add_argument("-f", "--from", dest="date_from")
+    metadata_parser.add_argument("-t", "--to", dest="date_to")
+    metadata_parser.add_argument("-s", "--skip", type=int, default=0)
+    metadata_parser.add_argument("-l", "--limit", type=int, default=0)
+    metadata_parser.add_argument("-S", "--sort", choices=["newest", "oldest"], default="newest")
+    metadata_parser.add_argument("-F", "--format", choices=["json", "ndjson"], default="json")
     metadata_parser.set_defaults(handler=handle_metadata)
 
     rabbitmq_queues_parser = telemetry_commands.add_parser(

--- a/dp3/bin/shcmd/telemetry.py
+++ b/dp3/bin/shcmd/telemetry.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Telemetry commands for the shell-oriented DP3 CLI."""
+
+from dp3.bin.shcmd.common import print_response_json, stream_json_pages
+
+
+def handle_sources_validity(client, _args) -> int:
+    """Show source validity timestamps."""
+    return print_response_json(client.request("GET", "/telemetry/sources_validity"))
+
+
+def handle_source_age(client, args) -> int:
+    """Show source ages in the requested unit."""
+    return print_response_json(
+        client.request("GET", "/telemetry/sources_age", params={"unit": args.unit})
+    )
+
+
+def handle_entities_per_attr(client, _args) -> int:
+    """Count entities with data present for each attribute."""
+    return print_response_json(client.request("GET", "/telemetry/entities_per_attr"))
+
+
+def handle_snapshot_summary(client, _args) -> int:
+    """Show recent snapshot activity summary."""
+    return print_response_json(client.request("GET", "/telemetry/snapshot_summary"))
+
+
+def handle_metadata(client, args) -> int:
+    """Browse internal metadata records."""
+    params = {
+        "skip": args.skip,
+        "limit": args.limit,
+        "sort": args.sort,
+    }
+    if args.module is not None:
+        params["module"] = args.module
+    if args.date_from is not None:
+        params["date_from"] = args.date_from
+    if args.date_to is not None:
+        params["date_to"] = args.date_to
+
+    if args.format == "ndjson":
+        base_params = {k: v for k, v in params.items() if k not in {"skip", "limit"}}
+        return stream_json_pages(client, "/telemetry/metadata", base_params, args.skip, args.limit)
+    return print_response_json(client.request("GET", "/telemetry/metadata", params=params))
+
+
+def handle_rabbitmq_queues(client, _args) -> int:
+    """Show RabbitMQ queue telemetry."""
+    return print_response_json(client.request("GET", "/telemetry/rabbitmq/queues"))
+
+
+def register_parser(commands) -> None:
+    """Register telemetry commands on the root parser."""
+    telemetry_parser = commands.add_parser("telemetry", help="Read operational telemetry.")
+    telemetry_commands = telemetry_parser.add_subparsers(dest="telemetry_command", required=True)
+
+    sources_validity_parser = telemetry_commands.add_parser(
+        "sources-validity", help="Show source validity timestamps."
+    )
+    sources_validity_parser.set_defaults(handler=handle_sources_validity)
+
+    source_age_parser = telemetry_commands.add_parser("source-age", help="Show source ages.")
+    source_age_parser.add_argument("--unit", choices=["minutes", "seconds"], default="minutes")
+    source_age_parser.set_defaults(handler=handle_source_age)
+
+    entities_per_attr_parser = telemetry_commands.add_parser(
+        "entities-per-attr", help="Count entities with data present for each attribute."
+    )
+    entities_per_attr_parser.set_defaults(handler=handle_entities_per_attr)
+
+    snapshot_summary_parser = telemetry_commands.add_parser(
+        "snapshot-summary", help="Show recent snapshot activity summary."
+    )
+    snapshot_summary_parser.set_defaults(handler=handle_snapshot_summary)
+
+    metadata_parser = telemetry_commands.add_parser(
+        "metadata", help="Browse internal metadata records."
+    )
+    metadata_parser.add_argument("--module")
+    metadata_parser.add_argument("--from", dest="date_from")
+    metadata_parser.add_argument("--to", dest="date_to")
+    metadata_parser.add_argument("--skip", type=int, default=0)
+    metadata_parser.add_argument("--limit", type=int, default=0)
+    metadata_parser.add_argument("--sort", choices=["newest", "oldest"], default="newest")
+    metadata_parser.add_argument("--format", choices=["json", "ndjson"], default="json")
+    metadata_parser.set_defaults(handler=handle_metadata)
+
+    rabbitmq_queues_parser = telemetry_commands.add_parser(
+        "rabbitmq-queues", help="Show RabbitMQ queue telemetry."
+    )
+    rabbitmq_queues_parser.set_defaults(handler=handle_rabbitmq_queues)

--- a/dp3/bin/shcmd/telemetry.py
+++ b/dp3/bin/shcmd/telemetry.py
@@ -89,7 +89,7 @@ def register_parser(commands) -> None:
     metadata_parser.add_argument("-s", "--skip", type=int, default=0)
     metadata_parser.add_argument("-l", "--limit", type=int, default=0)
     metadata_parser.add_argument("-S", "--sort", choices=["newest", "oldest"], default="newest")
-    metadata_parser.add_argument("-F", "--format", choices=["json", "ndjson"], default="json")
+    metadata_parser.add_argument("-F", "--format", choices=["json", "ndjson"], default="ndjson")
     metadata_parser.set_defaults(handler=handle_metadata)
 
     rabbitmq_queues_parser = telemetry_commands.add_parser(

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -199,6 +199,43 @@ class EntityDatabase:
         """
         return self._db.get_collection(f"{entity}#raw", **kwargs)
 
+    def find_raw_datapoints(
+        self,
+        etype: str,
+        eid: AnyEidT = None,
+        attr: str = None,
+        src: str = None,
+        skip: int = 0,
+        limit: int = 0,
+    ) -> Cursor:
+        """Find raw datapoints for an entity type with optional troubleshooting filters."""
+        self._assert_etype_exists(etype)
+
+        query = {}
+        if eid is not None:
+            self._assert_eid_correct_dtype(etype, eid)
+            query["eid"] = eid
+        if attr is not None:
+            query["attr"] = attr
+        if src is not None:
+            query["src"] = src
+
+        try:
+            cursor = self._raw_col(etype).find(query, projection={"_id": False})
+            sort = [("$natural", pymongo.DESCENDING)]
+            if attr is not None and attr in self._db_schema_config.attribs(etype):
+                attr_spec = self._db_schema_config.attr(etype, attr)
+                if attr_spec.t in AttrType.TIMESERIES | AttrType.OBSERVATIONS:
+                    sort = [("t1", pymongo.DESCENDING), ("_id", pymongo.DESCENDING)]
+            cursor = cursor.sort(sort)
+            if skip:
+                cursor = cursor.skip(skip)
+            if limit:
+                cursor = cursor.limit(limit)
+            return cursor
+        except Exception as e:
+            raise DatabaseError(f"Raw datapoint fetch failed: {e}") from e
+
     @staticmethod
     def _get_new_archive_col_name(entity: str) -> str:
         """Returns name of new archive collection for `entity`."""

--- a/dp3/database/database.py
+++ b/dp3/database/database.py
@@ -877,6 +877,45 @@ class EntityDatabase:
         except Exception as e:
             raise DatabaseError(f"Update of metadata failed: {e}\n{metadata_id}, {changes}") from e
 
+    def find_metadata(
+        self,
+        module: str = None,
+        date_from: datetime = None,
+        date_to: datetime = None,
+        newest_first: bool = True,
+        extra_filter: dict = None,
+    ) -> Cursor:
+        """Find metadata documents with optional filtering."""
+        query = dict(extra_filter or {})
+        if module is not None:
+            query["#module"] = module
+
+        time_filter = {}
+        if date_from is not None:
+            time_filter["$gte"] = date_from
+        if date_to is not None:
+            time_filter["$lte"] = date_to
+        if time_filter:
+            query["#time_created"] = time_filter
+
+        sort_dir = pymongo.DESCENDING if newest_first else pymongo.ASCENDING
+        return (
+            self._db["#metadata"].find(query).sort([("#time_created", sort_dir), ("_id", sort_dir)])
+        )
+
+    def count_entities_per_attr(self) -> dict[str, dict[str, int]]:
+        """Count entities with data present for each configured attribute per entity type."""
+        counts: dict[str, dict[str, int]] = {}
+        for (etype, attr), spec in self._db_schema_config.attributes.items():
+            if spec.t in AttrType.TIMESERIES | AttrType.OBSERVATIONS:
+                field = f"#min_t2s.{attr}"
+            else:
+                field = f"{attr}.ts_last_update"
+            counts.setdefault(etype, {})[attr] = self._master_col(etype).count_documents(
+                {field: {"$exists": True}}
+            )
+        return counts
+
     def get_observation_history(
         self,
         etype: str,

--- a/dp3/database/magic.py
+++ b/dp3/database/magic.py
@@ -149,7 +149,7 @@ def search_and_replace(query: dict[str, Any]) -> dict[str, Any]:
     """Search and replace all occurrences of magic strings in the query.
 
     A helper function to
-    [`snapshots.get_latest`][dp3.database.snapshots.TypedSnapshotCollection.get_latest]
+    [`snapshots.find_latest`][dp3.database.snapshots.TypedSnapshotCollection.find_latest]
     """
     if isinstance(query, dict):
         for key, value in query.items():

--- a/dp3/database/snapshots.py
+++ b/dp3/database/snapshots.py
@@ -649,7 +649,7 @@ class TypedSnapshotCollection(abc.ABC):
             raise SnapshotCollectionError(f"Delete of olds snapshots failed: {e}") from e
         return deleted
 
-    def delete_eid(self, eid: AnyEidT):
+    def delete_eid(self, eid: AnyEidT) -> int:
         """Delete all snapshots of `eid`."""
         try:
             res = self._col().delete_many(self._filter_from_eid(eid))
@@ -660,10 +660,11 @@ class TypedSnapshotCollection(abc.ABC):
             self.log.debug(
                 "Deleted %s oversized snapshots of %s/%s.", res.deleted_count, self.entity_type, eid
             )
+            return del_cnt + res.deleted_count
         except Exception as e:
             raise SnapshotCollectionError(f"Delete of failed: {e}\n{eid}") from e
 
-    def delete_eids(self, eids: list[Any]):
+    def delete_eids(self, eids: list[Any]) -> int:
         """Delete all snapshots of `eids`."""
         try:
             res = self._col().delete_many(self._filter_from_eids(eids))
@@ -676,6 +677,7 @@ class TypedSnapshotCollection(abc.ABC):
                 self.entity_type,
                 len(eids),
             )
+            return del_cnt + res.deleted_count
         except Exception as e:
             raise SnapshotCollectionError(f"Delete of snapshots failed: {e}\n{eids}") from e
 

--- a/dp3/database/snapshots.py
+++ b/dp3/database/snapshots.py
@@ -152,12 +152,12 @@ class TypedSnapshotCollection(abc.ABC):
             self._col().find_one(self._filter_from_eid(eid), {"last": 1}, sort=[("_id", -1)]) or {}
         ).get("last", {})
 
-    def get_latest(
+    def find_latest(
         self,
         fulltext_filters: Optional[dict[str, str]] = None,
         generic_filter: Optional[dict[str, Any]] = None,
-    ) -> tuple[Cursor, int]:
-        """Get latest snapshots of given `etype`.
+    ) -> Cursor:
+        """Find latest snapshots of given `etype`.
 
         This method is useful for displaying data on web.
 
@@ -180,29 +180,7 @@ class TypedSnapshotCollection(abc.ABC):
 
         Generic and fulltext filters are merged - fulltext overrides conflicting keys.
 
-        Also returns total document count (after filtering).
-
         May raise `SnapshotCollectionError` if query is invalid.
-        """
-        snapshot_col = self._col()
-        query = self._prepare_latest_query(fulltext_filters or {}, generic_filter or {})
-
-        try:
-            return snapshot_col.find(query, {"last": 1}).sort(
-                [("_id", pymongo.ASCENDING)]
-            ), snapshot_col.count_documents(query)
-        except OperationFailure as e:
-            raise SnapshotCollectionError(f"Query is invalid: {e}") from e
-
-    def find_latest(
-        self,
-        fulltext_filters: Optional[dict[str, str]] = None,
-        generic_filter: Optional[dict[str, Any]] = None,
-    ) -> Cursor:
-        """Find latest snapshots of given `etype`.
-
-        See [`get_latest`][dp3.database.snapshots.SnapshotCollectionContainer.get_latest]
-        for more information.
 
         Returns only documents matching `generic_filter` and `fulltext_filters`,
         does not count them.
@@ -220,12 +198,12 @@ class TypedSnapshotCollection(abc.ABC):
     ) -> int:
         """Count latest snapshots of given `etype`.
 
-        See [`get_latest`][dp3.database.snapshots.SnapshotCollectionContainer.get_latest]
+        See [`find_latest`][dp3.database.snapshots.SnapshotCollectionContainer.find_latest]
         for more information.
 
         Returns only count of documents matching `generic_filter` and `fulltext_filters`.
 
-        Note that this method may take much longer than `get_latest` on larger databases,
+        Note that this method may take much longer than `find_latest` on larger databases,
         as it does count all documents, not just return the first few.
         """
         query = self._prepare_latest_query(fulltext_filters or {}, generic_filter or {})
@@ -784,13 +762,13 @@ class SnapshotCollectionContainer:
         """
         return self[entity_type].get_latest_one(eid)
 
-    def get_latest(
+    def find_latest(
         self,
         entity_type: str,
         fulltext_filters: Optional[dict[str, str]] = None,
         generic_filter: Optional[dict[str, Any]] = None,
-    ) -> tuple[Cursor, int]:
-        """Get latest snapshots of given `etype`.
+    ) -> Cursor:
+        """Find latest snapshots of given `etype`.
 
         This method is useful for displaying data on web.
 
@@ -813,22 +791,7 @@ class SnapshotCollectionContainer:
 
         Generic and fulltext filters are merged - fulltext overrides conflicting keys.
 
-        Also returns total document count (after filtering).
-
         May raise `SnapshotCollectionError` if query is invalid.
-        """
-        return self[entity_type].get_latest(fulltext_filters, generic_filter)
-
-    def find_latest(
-        self,
-        entity_type: str,
-        fulltext_filters: Optional[dict[str, str]] = None,
-        generic_filter: Optional[dict[str, Any]] = None,
-    ) -> Cursor:
-        """Find latest snapshots of given `etype`.
-
-        see [`get_latest`][dp3.database.snapshots.SnapshotCollectionContainer.get_latest]
-        for more information.
 
         Returns only documents matching `generic_filter` and `fulltext_filters`,
         does not count them.
@@ -843,12 +806,12 @@ class SnapshotCollectionContainer:
     ) -> int:
         """Count latest snapshots of given `etype`.
 
-        see [`get_latest`][dp3.database.snapshots.SnapshotCollectionContainer.get_latest]
+        see [`find_latest`][dp3.database.snapshots.SnapshotCollectionContainer.find_latest]
         for more information.
 
         Returns only count of documents matching `generic_filter` and `fulltext_filters`.
 
-        Note that this method may take much longer than `get_latest` on larger databases,
+        Note that this method may take much longer than `find_latest` on larger databases,
         as it does count all documents, not just return the first few.
         """
         return self[entity_type].count_latest(fulltext_filters, generic_filter)

--- a/dp3/database/snapshots.py
+++ b/dp3/database/snapshots.py
@@ -249,7 +249,12 @@ class TypedSnapshotCollection(abc.ABC):
         return query
 
     def get_by_eid(
-        self, eid: AnyEidT, t1: Optional[datetime] = None, t2: Optional[datetime] = None
+        self,
+        eid: AnyEidT,
+        t1: Optional[datetime] = None,
+        t2: Optional[datetime] = None,
+        skip: int = 0,
+        limit: int = 0,
     ) -> Union[Cursor, CommandCursor]:
         """Get all (or filtered) snapshots of given `eid`.
 
@@ -259,6 +264,8 @@ class TypedSnapshotCollection(abc.ABC):
             eid: id of entity, to which data-points correspond
             t1: left value of time interval (inclusive)
             t2: right value of time interval (inclusive)
+            skip: number of snapshots to skip
+            limit: max number of snapshots to return, `0` means no limit
         """
         snapshot_col = self._col()
 
@@ -270,7 +277,7 @@ class TypedSnapshotCollection(abc.ABC):
         )
         doc = next(doc, None)
         if doc and doc.get("oversized", False):
-            return self._get_oversized(eid, t1, t2)
+            return self._get_oversized(eid, t1, t2, skip, limit)
 
         query = {"_time_created": {}}
         pipeline = [
@@ -288,7 +295,12 @@ class TypedSnapshotCollection(abc.ABC):
         # Unset if empty
         if query["_time_created"]:
             pipeline.append({"$match": query})
+
         pipeline.append({"$sort": {"_time_created": pymongo.ASCENDING}})
+        if skip:
+            pipeline.append({"$skip": skip})
+        if limit:
+            pipeline.append({"$limit": limit})
         return snapshot_col.aggregate(pipeline)
 
     def get_distinct_val_count(self, attr: str) -> dict[Any, int]:
@@ -346,7 +358,12 @@ class TypedSnapshotCollection(abc.ABC):
         return distinct_counts
 
     def _get_oversized(
-        self, eid: AnyEidT, t1: Optional[datetime] = None, t2: Optional[datetime] = None
+        self,
+        eid: AnyEidT,
+        t1: Optional[datetime] = None,
+        t2: Optional[datetime] = None,
+        skip: int = 0,
+        limit: int = 0,
     ) -> Cursor:
         """Get all (or filtered) snapshots of given `eid` from oversized snapshots collection."""
         snapshot_col = self._os_col()
@@ -362,9 +379,14 @@ class TypedSnapshotCollection(abc.ABC):
         if not query["_time_created"]:
             del query["_time_created"]
 
-        return snapshot_col.find(query, projection={"_id": False}).sort(
+        cursor = snapshot_col.find(query, projection={"_id": False}).sort(
             [("_time_created", pymongo.ASCENDING)]
         )
+        if skip:
+            cursor = cursor.skip(skip)
+        if limit:
+            cursor = cursor.limit(limit)
+        return cursor
 
     def _migrate_to_oversized(self, eid: AnyEidT, snapshot: dict):
         snapshot_col = self._col()
@@ -822,6 +844,8 @@ class SnapshotCollectionContainer:
         eid: AnyEidT,
         t1: Optional[datetime] = None,
         t2: Optional[datetime] = None,
+        skip: int = 0,
+        limit: int = 0,
     ) -> Union[Cursor, CommandCursor]:
         """Get all (or filtered) snapshots of given `eid`.
 
@@ -832,8 +856,10 @@ class SnapshotCollectionContainer:
             eid: id of entity, to which data-points correspond
             t1: left value of time interval (inclusive)
             t2: right value of time interval (inclusive)
+            skip: number of snapshots to skip
+            limit: max number of snapshots to return, `0` means no limit
         """
-        return self[entity_type].get_by_eid(eid, t1, t2)
+        return self[entity_type].get_by_eid(eid, t1, t2, skip, limit)
 
     def get_distinct_val_count(self, entity_type: str, attr: str) -> dict[Any, int]:
         """Counts occurrences of distinct values of given attribute in snapshots.

--- a/dp3/history_management/telemetry.py
+++ b/dp3/history_management/telemetry.py
@@ -3,12 +3,14 @@ import threading
 import time
 from datetime import datetime
 
+import requests
 from pymongo import ASCENDING, UpdateOne
 
 from dp3.common.callback_registrar import CallbackRegistrar
 from dp3.common.config import PlatformConfig
 from dp3.common.datapoint import DataPointObservationsBase, DataPointTimeseriesBase
 from dp3.common.task import DataPointTask
+from dp3.common.types import UTC
 from dp3.database.database import EntityDatabase
 
 
@@ -105,19 +107,132 @@ class Telemetry:
 
 
 class TelemetryReader:
-    """Reader of telemetry data
+    """Reader of telemetry data.
 
     Used by API.
     Not contained inside `Telemetry` class due to usage of `CallbackRegistrar`
-    and all of it's requirements (doesn't make sense for API).
+    and all of its requirements.
     """
 
-    def __init__(self, db: EntityDatabase) -> None:
+    exported_queue_keys = {
+        "messages": "total",
+        "messages_ready": "ready",
+        "messages_unacknowledged": "unacked",
+        "consumers": "consumers",
+        "memory": "memory",
+        "message_bytes": "message_bytes",
+    }
+    exported_message_stats_keys = {
+        "publish_details": "incoming",
+        "deliver_get_details": "outgoing",
+    }
+
+    def __init__(
+        self,
+        db: EntityDatabase,
+        app_name: str,
+        num_processes: int,
+        rabbit_config: dict,
+    ) -> None:
         self.db = db
+        self.app_name = app_name
+        self.num_processes = num_processes
+        self.rabbit_config = rabbit_config or {}
         self.cache_col = self.db.get_module_cache("Telemetry")
 
     def get_sources_validity(self) -> dict[str, datetime]:
         """Return timestamps (datetimes) of current validity of all sources."""
         src_data = self.cache_col.find({}).sort([("_id", ASCENDING)])
-
         return {src["_id"]: src["src_t"] for src in src_data}
+
+    def get_sources_age(self, unit: str = "minutes") -> dict[str, int]:
+        """Return ages of sources relative to now in requested units."""
+        now = datetime.now(UTC)
+        divider = 60 if unit == "minutes" else 1
+        return {
+            source: int((now - timestamp).total_seconds() / divider)
+            for source, timestamp in self.get_sources_validity().items()
+        }
+
+    def get_entities_per_attr(self) -> dict[str, dict[str, int]]:
+        """Return counts of entities with data present for each configured attribute."""
+        return self.db.count_entities_per_attr()
+
+    def get_snapshot_summary(self) -> dict:
+        """Return summary of latest snapshot activity."""
+        now = datetime.now(UTC)
+        latest_started = next(self.db.find_metadata(module="SnapShooter").limit(1), None)
+        latest_finished = next(
+            self.db.find_metadata(
+                module="SnapShooter",
+                extra_filter={"workers_finished": self.num_processes, "linked_finished": True},
+            ).limit(1),
+            None,
+        )
+
+        summary = {
+            "latest_age": None,
+            "finished_age": None,
+            "entities": None,
+            "total_s": None,
+        }
+        if latest_started is not None:
+            summary["latest_age"] = (now - latest_started["#time_created"]).total_seconds()
+        if latest_finished is not None:
+            summary["finished_age"] = (now - latest_finished["#time_created"]).total_seconds()
+            summary["entities"] = latest_finished.get("entities")
+            summary["total_s"] = (
+                latest_finished["#last_update"] - latest_finished["#time_created"]
+            ).total_seconds()
+        return summary
+
+    def get_metadata(
+        self,
+        module: str = None,
+        date_from: datetime = None,
+        date_to: datetime = None,
+        newest_first: bool = True,
+        skip: int = 0,
+        limit: int = 0,
+    ) -> list[dict]:
+        """Return filtered metadata documents."""
+        cursor = self.db.find_metadata(module, date_from, date_to, newest_first)
+        if skip:
+            cursor = cursor.skip(skip)
+        if limit:
+            cursor = cursor.limit(limit)
+        return list(cursor)
+
+    def get_rabbitmq_queues(self) -> dict[str, list[dict]]:
+        """Return RabbitMQ queue telemetry for this application."""
+        host = self.rabbit_config.get("host", "localhost")
+        port = int(self.rabbit_config.get("management_port", 15672))
+        username = self.rabbit_config.get("username", "guest")
+        password = self.rabbit_config.get("password", "guest")
+        response = requests.get(
+            f"http://{host}:{port}/api/queues",
+            auth=(username, password),
+            timeout=5,
+        )
+        response.raise_for_status()
+
+        queues = []
+        app_prefix = f"{self.app_name}-worker-"
+        for queue in response.json():
+            queue_name = queue.get("name", "")
+            if not queue_name.startswith(app_prefix):
+                continue
+
+            short_name = queue_name[len(app_prefix) :]
+            alias = short_name if len(short_name) > 2 else f"{short_name}-main"
+            queue_data = {"name": queue_name, "queue": alias}
+            for key, alias_key in self.exported_queue_keys.items():
+                queue_data[alias_key] = queue.get(key, 0)
+
+            message_stats = queue.get("message_stats", {})
+            for key, alias_key in self.exported_message_stats_keys.items():
+                queue_data[alias_key] = message_stats.get(key, {}).get("rate", 0)
+            queues.append(queue_data)
+
+        queues.sort(key=lambda item: item["queue"])
+        return {"queues": queues}

--- a/dp3/template/appsh
+++ b/dp3/template/appsh
@@ -1,2 +1,12 @@
 #!/bin/sh
+
+if [ -n "${_ARGCOMPLETE:-}" ] && [ -n "${COMP_LINE:-}" ] && [ -n "${COMP_POINT:-}" ]; then
+    wrapper_name="${0##*/}"
+    completion_prefix="{{DP3_EXE}} sh"
+    completion_suffix="${COMP_LINE#"$wrapper_name"}"
+    COMP_LINE="$completion_prefix$completion_suffix"
+    COMP_POINT=$((COMP_POINT + ${#completion_prefix} - ${#wrapper_name}))
+    export COMP_LINE COMP_POINT
+fi
+
 DP3_CONFIG_DIR="{{CONFIG_DIR}}" exec {{DP3_EXE}} sh "$@"

--- a/dp3/template/appsh
+++ b/dp3/template/appsh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec {{DP3_EXE}} sh --config "{{CONFIG_DIR}}" "$@"
+DP3_CONFIG_DIR="{{CONFIG_DIR}}" exec {{DP3_EXE}} sh "$@"

--- a/dp3/template/appsh
+++ b/dp3/template/appsh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec {{DP3_EXE}} sh --config "{{CONFIG_DIR}}" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 AMQPStorm~=2.7.2
 apscheduler~=3.10.0
+argcomplete~=3.6.0
 event-count-logger>=1.1
 fastapi>=0.109.1
 pydantic>=2.4.0

--- a/scripts/run_api_test_shard.py
+++ b/scripts/run_api_test_shard.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+
+
+def main() -> int:
+    sys.path.insert(0, os.path.abspath("tests/test_api"))
+
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for module_name in sys.argv[1:]:
+        suite.addTests(loader.loadTestsFromName(module_name))
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_api_tests_local.sh
+++ b/scripts/run_api_tests_local.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+COMPOSE=(docker compose)
+RESET_SERVICES=(mongo rabbitmq redis receiver_api worker)
+RUNNER_PATH=/dp3/scripts/run_api_test_shard.py
+TEST_API_DIR=tests/test_api
+
+PARALLEL_GC_SHARD=(
+  test_garbage_collector
+)
+
+PARALLEL_NON_GC_SHARD=()
+
+build_non_gc_shard() {
+  local gc_module
+  local module_path
+  local module_name
+  declare -A gc_modules=()
+
+  for gc_module in "${PARALLEL_GC_SHARD[@]}"; do
+    gc_modules["$gc_module"]=1
+  done
+
+  mapfile -t PARALLEL_NON_GC_SHARD < <(
+    find "$TEST_API_DIR" -maxdepth 1 -type f -name 'test_*.py' \
+      | sort \
+      | while read -r module_path; do
+          module_name="${module_path##*/}"
+          module_name="${module_name%.py}"
+          if [[ -z "${gc_modules[$module_name]:-}" ]]; then
+            printf '%s\n' "$module_name"
+          fi
+        done
+  )
+}
+
+cleanup_stack() {
+  # The Mongo image uses anonymous volumes for /data/db and /data/configdb.
+  # Removing containers alone leaves prior test data behind and makes API tests flaky.
+  "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+run_shard() {
+  local log_file=$1
+  shift
+
+  local api_container_id
+  api_container_id="$("${COMPOSE[@]}" ps -q receiver_api)"
+
+  docker run \
+    --rm \
+    --volume "$ROOT_DIR/scripts/run_api_test_shard.py:$RUNNER_PATH:ro" \
+    --env CONF_DIR=/dp3/tests/test_config \
+    --network "container:${api_container_id}" \
+    dp3_interpreter \
+    python "$RUNNER_PATH" "$@" >"$log_file" 2>&1
+}
+
+if [[ "${1:-}" == "cleanup" ]]; then
+  cleanup_stack
+  exit 0
+fi
+
+build_non_gc_shard
+
+echo "Starting local API test run from $ROOT_DIR"
+echo "Recreating: ${RESET_SERVICES[*]}"
+echo "Parallel shard A: ${PARALLEL_NON_GC_SHARD[*]}"
+echo "Parallel shard B: ${PARALLEL_GC_SHARD[*]}"
+
+cleanup_stack
+
+# Build the interpreter and RabbitMQ images in parallel.
+docker build -f docker/python/Dockerfile --target base -t dp3_interpreter . &
+docker build -f docker/rabbitmq/Dockerfile -t dp3_rabbitmq docker/rabbitmq &
+wait
+
+"${COMPOSE[@]}" up -d --force-recreate "${RESET_SERVICES[@]}"
+
+sleep 10
+
+parallel_non_gc_log="$(mktemp)"
+parallel_gc_log="$(mktemp)"
+cleanup_logs() {
+  rm -f "$parallel_non_gc_log" "$parallel_gc_log"
+}
+trap cleanup_logs EXIT
+
+set +e
+run_shard "$parallel_non_gc_log" "${PARALLEL_NON_GC_SHARD[@]}" &
+non_gc_pid=$!
+run_shard "$parallel_gc_log" "${PARALLEL_GC_SHARD[@]}" &
+gc_pid=$!
+
+wait $non_gc_pid
+non_gc_status=$?
+wait $gc_pid
+gc_status=$?
+set -e
+
+cat "$parallel_non_gc_log"
+cat "$parallel_gc_log"
+
+status=0
+if [[ $non_gc_status -ne 0 || $gc_status -ne 0 ]]; then
+  status=1
+  echo "API tests failed; recent service logs follow." >&2
+  "${COMPOSE[@]}" logs --tail=200 "${RESET_SERVICES[@]}" >&2 || true
+fi
+
+exit "$status"

--- a/tests/test_api/test_get_entity_eids.py
+++ b/tests/test_api/test_get_entity_eids.py
@@ -24,7 +24,7 @@ class GetEntityEids(common.APITest):
         sleep(6)
 
     def test_get_entity_eids(self):
-        eids = self.get_entity_data("entity/A", EntityEidList)
+        eids = self.get_entity_data("entity/A/get", EntityEidList)
         self.assertEqual(20, len(eids.data))
 
     def test_get_entity_eids_pagination(self):
@@ -32,24 +32,24 @@ class GetEntityEids(common.APITest):
         received_eids = set()
 
         for i in range(0, 100, 10):
-            eids = self.get_entity_data("entity/A", EntityEidList, skip=i, limit=10)
+            eids = self.get_entity_data("entity/A/get", EntityEidList, skip=i, limit=10)
             self.assertEqual(10, len(eids.data), f"Failed at {i}")
             received_eids.update(x["eid"] for x in eids.data)
 
-        eids = self.get_entity_data("entity/A", EntityEidList, skip=102, limit=20)
+        eids = self.get_entity_data("entity/A/get", EntityEidList, skip=102, limit=20)
         self.assertEqual(0, len(eids.data))
         self.assertSetEqual(expected_eids, received_eids)
 
     def test_get_entity_eids_generic_filter(self):
         eids = self.get_entity_data(
-            "entity/A", EntityEidList, generic_filter=json.dumps({"last.eid": 0})
+            "entity/A/get", EntityEidList, generic_filter=json.dumps({"last.eid": 0})
         )
         self.assertEqual(1, len(eids.data))
         self.assertEqual(0, eids.data[0]["eid"])
 
     def test_get_entity_eids_generic_filters_eid(self):
         eids = self.get_entity_data(
-            "entity/A",
+            "entity/A/get",
             EntityEidList,
             generic_filter=json.dumps(
                 {"$or": [{"last.eid": 5}, {"last.eid": {"$gte": 50, "$lt": 60}}]}

--- a/tests/test_api/test_raw.py
+++ b/tests/test_api/test_raw.py
@@ -1,0 +1,86 @@
+import datetime
+import json
+import sys
+
+import common
+
+from dp3.api.internal.entity_response_models import EntityRawDataPage
+from dp3.common.types import UTC
+
+
+class RawDatapointsIntegration(common.APITest):
+    raw_src = "raw-debug@test"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        now = datetime.datetime.now(UTC)
+        first_t1 = (now - datetime.timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+        first_t2 = (now - datetime.timedelta(minutes=9)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+        second_t1 = (now - datetime.timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+        second_t2 = (now - datetime.timedelta(minutes=4)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+
+        datapoints = [
+            {"type": "A", "id": 9101, "attr": "data1", "v": "plain-1", "src": cls.raw_src},
+            {"type": "A", "id": 9102, "attr": "data1", "v": "plain-2", "src": cls.raw_src},
+            {
+                "type": "A",
+                "id": 9101,
+                "attr": "as",
+                "v": {"eid": 9102},
+                "t1": first_t1,
+                "t2": first_t2,
+                "c": 1.0,
+                "src": cls.raw_src,
+            },
+            {
+                "type": "A",
+                "id": 9101,
+                "attr": "as",
+                "v": {"eid": 9103},
+                "t1": second_t1,
+                "t2": second_t2,
+                "c": 1.0,
+                "src": cls.raw_src,
+            },
+        ]
+
+        response = cls.push_datapoints(datapoints)
+        if response.status_code != 200:
+            print(json.dumps(response.json(), indent=2), file=sys.stderr)
+            raise Exception(f"Failed to push datapoints: {response.status_code}")
+
+    def test_get_raw_datapoints(self):
+        payload = self.query_expected_value(
+            lambda: self.get_request(
+                "entity/A/raw/get",
+                eid=9101,
+                attr="as",
+                src=self.raw_src,
+                limit=2,
+            ).json(),
+            lambda data: data["count"] == 2,
+            msg="Timed out waiting for raw datapoints to appear.",
+        )
+        page = EntityRawDataPage.model_validate(payload)
+        self.assertEqual(2, page.count)
+        self.assertEqual([9103, 9102], [item["v"]["eid"] for item in page.data])
+        self.assertEqual(["A", "A"], [item["type"] for item in page.data])
+        self.assertEqual([9101, 9101], [item["id"] for item in page.data])
+        self.assertNotIn("etype", page.data[0])
+        self.assertNotIn("eid", page.data[0])
+
+    def test_get_plain_raw_datapoints_newest_first(self):
+        payload = self.query_expected_value(
+            lambda: self.get_request(
+                "entity/A/raw/get",
+                attr="data1",
+                src=self.raw_src,
+                limit=2,
+            ).json(),
+            lambda data: data["count"] == 2,
+            msg="Timed out waiting for plain raw datapoints to appear.",
+        )
+        page = EntityRawDataPage.model_validate(payload)
+        self.assertEqual(["plain-2", "plain-1"], [item["v"] for item in page.data])
+        self.assertEqual([9102, 9101], [item["id"] for item in page.data])

--- a/tests/test_api/test_snapshots.py
+++ b/tests/test_api/test_snapshots.py
@@ -5,7 +5,7 @@ from time import sleep
 
 import common
 
-from dp3.api.internal.entity_response_models import EntityEidData
+from dp3.api.internal.entity_response_models import EntityEidData, EntityEidSnapshots
 from dp3.common.types import UTC
 
 
@@ -97,3 +97,9 @@ class SnapshotIntegration(common.APITest):
             self.assertEqual(snapshot["data3"], "master_test")
             # The hook should have set data4 to data3 from master record + "_from_master"
             self.assertEqual(snapshot["data4"], "master_test_from_master")
+
+    def test_paged_snapshots_on_main_endpoint(self):
+        response = self.get_request("entity/A/420/snapshots", limit=1)
+        self.assertEqual(response.status_code, 200)
+        data = EntityEidSnapshots(response.json())
+        self.assertEqual(len(data), 1)

--- a/tests/test_api/test_telemetry.py
+++ b/tests/test_api/test_telemetry.py
@@ -1,0 +1,60 @@
+import datetime
+import json
+import sys
+from time import sleep
+
+import common
+
+from dp3.common.types import UTC
+
+
+class TelemetryEndpoints(common.APITest):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        now = datetime.datetime.now(UTC)
+        t1 = (now - datetime.timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+        t2 = (now + datetime.timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4]
+
+        datapoints = [
+            {"type": "A", "id": 999, "attr": "data1", "v": "telemetry-test"},
+            {
+                "type": "A",
+                "id": 999,
+                "attr": "bs",
+                "v": {"eid": "telemetry-b"},
+                "t1": t1,
+                "t2": t2,
+                "c": 1.0,
+                "src": "telemetry-test",
+            },
+        ]
+        res = cls.push_datapoints(datapoints)
+        if res.status_code != 200:
+            print(json.dumps(res.json(), indent=2), sys.stderr)
+            raise Exception(f"Failed to push datapoints: {res.status_code}")
+
+        sleep(3)
+        cls.get_request("control/make_snapshots")
+        sleep(3)
+
+    def test_snapshot_summary_endpoint(self):
+        response = self.get_request("telemetry/snapshot_summary")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsNotNone(data["latest_age"])
+
+    def test_metadata_endpoint(self):
+        response = self.get_request("telemetry/metadata", module="SnapShooter", limit=1)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["#module"], "SnapShooter")
+
+    def test_entities_per_attr_endpoint(self):
+        response = self.get_request("telemetry/entities_per_attr")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("A", data)
+        self.assertIn("data1", data["A"])
+        self.assertGreaterEqual(data["A"]["data1"], 1)

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -46,14 +46,20 @@ class TestShCompletion(unittest.TestCase):
             values = complete_entity_type_names("A", args)
         self.assertEqual({"A": "Configured entity type."}, values)
 
-    def test_entity_scope_completion_includes_eid_placeholder(self):
+    def test_entity_scope_completion_includes_id_subcommand(self):
         values = self._get_completions(["dpsh", "--config", "tests/test_config", "entity", "A"], "")
-        self.assertIn("\\<EID\\>", values)
+        self.assertIn("id", values)
         self.assertIn("list", values)
+
+    def test_entity_id_completion_includes_eid_placeholder(self):
+        values = self._get_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "id"], ""
+        )
+        self.assertTrue(any("EID" in value for value in values))
 
     def test_snapshot_option_completion(self):
         values = self._get_completions(
-            ["dpsh", "--config", "tests/test_config", "entity", "A", "10", "snapshots"],
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "id", "10", "snapshots"],
             "--",
         )
         self.assertIn("--from", values)
@@ -62,7 +68,7 @@ class TestShCompletion(unittest.TestCase):
 
     def test_snapshot_option_completion_includes_descriptions(self):
         finder, values = self._finder_with_completions(
-            ["dpsh", "--config", "tests/test_config", "entity", "A", "10", "snapshots"],
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "id", "10", "snapshots"],
             "--",
         )
         self.assertIn("--from", values)
@@ -94,6 +100,7 @@ class TestShCompletion(unittest.TestCase):
                 "tests/test_config",
                 "entity",
                 "A",
+                "id",
                 "entity-1",
                 "attr",
                 "data1",

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -15,9 +15,13 @@ class TestShCompletion(unittest.TestCase):
         init_parser(parser)
         return parser
 
-    def _get_completions(self, comp_words, prefix):
+    def _finder_with_completions(self, comp_words, prefix):
         finder = CompletionFinder(self._create_parser(), always_complete_options=False)
-        return finder._get_completions(comp_words, prefix, "", None)
+        values = finder._get_completions(comp_words, prefix, "", None)
+        return finder, values
+
+    def _get_completions(self, comp_words, prefix):
+        return self._finder_with_completions(comp_words, prefix)[1]
 
     def test_top_level_completion_includes_entity_commands(self):
         values = self._get_completions(["dpsh"], "e")
@@ -40,7 +44,7 @@ class TestShCompletion(unittest.TestCase):
             ),
         ):
             values = complete_entity_type_names("A", args)
-        self.assertEqual(["A"], values)
+        self.assertEqual({"A": "Configured entity type."}, values)
 
     def test_entity_scope_completion_includes_eid_placeholder(self):
         values = self._get_completions(["dpsh", "--config", "tests/test_config", "entity", "A"], "")
@@ -56,6 +60,17 @@ class TestShCompletion(unittest.TestCase):
         self.assertIn("--to", values)
         self.assertIn("--limit", values)
 
+    def test_snapshot_option_completion_includes_descriptions(self):
+        finder, values = self._finder_with_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "10", "snapshots"],
+            "--",
+        )
+        self.assertIn("--from", values)
+        self.assertEqual(
+            "Lower bound of the snapshot time range.",
+            finder._display_completions.get("--from"),
+        )
+
     def test_entity_type_attr_completion_uses_config(self):
         values = self._get_completions(
             ["dpsh", "--config", "tests/test_config", "entity", "A", "attr"], "d"
@@ -63,6 +78,13 @@ class TestShCompletion(unittest.TestCase):
         self.assertIn("data1", values)
         self.assertIn("data2", values)
         self.assertIn("data3", values)
+
+    def test_entity_type_completion_includes_descriptions(self):
+        finder, values = self._finder_with_completions(
+            ["dpsh", "--config", "tests/test_config", "entity"], "A"
+        )
+        self.assertIn("A ", values)
+        self.assertTrue(finder._display_completions.get("A", "").startswith("test entity A"))
 
     def test_entity_instance_attr_action_completion(self):
         values = self._get_completions(

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -57,6 +57,14 @@ class TestShCompletion(unittest.TestCase):
         )
         self.assertTrue(any("EID" in value for value in values))
 
+    def test_entity_list_option_completion(self):
+        values = self._get_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "list"],
+            "--",
+        )
+        self.assertIn("--format", values)
+        self.assertIn("--limit", values)
+
     def test_snapshot_option_completion(self):
         values = self._get_completions(
             ["dpsh", "--config", "tests/test_config", "entity", "A", "id", "10", "snapshots"],
@@ -65,6 +73,16 @@ class TestShCompletion(unittest.TestCase):
         self.assertIn("--from", values)
         self.assertIn("--to", values)
         self.assertIn("--limit", values)
+
+    def test_entity_list_option_completion_includes_descriptions(self):
+        finder, values = self._finder_with_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "list"],
+            "--",
+        )
+        self.assertIn("--format", values)
+        self.assertEqual(
+            "Choose JSON or NDJSON output.", finder._display_completions.get("--format")
+        )
 
     def test_snapshot_option_completion_includes_descriptions(self):
         finder, values = self._finder_with_completions(

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -105,6 +105,12 @@ class TestShCompletion(unittest.TestCase):
         self.assertEqual(2, parsed_args.limit)
         self.assertEqual("ndjson", parsed_args.format)
 
+    def test_entity_list_default_format_is_ndjson(self):
+        args = self._parse_args(["entity", "A", "list"])
+        parsed_args, exit_code = args.prepare_args(args)
+        self.assertIsNone(exit_code)
+        self.assertEqual("ndjson", parsed_args.format)
+
     def test_telemetry_short_options_parse(self):
         args = self._parse_args(
             [
@@ -132,6 +138,10 @@ class TestShCompletion(unittest.TestCase):
         self.assertEqual(1, args.skip)
         self.assertEqual(2, args.limit)
         self.assertEqual("oldest", args.sort)
+        self.assertEqual("ndjson", args.format)
+
+    def test_telemetry_metadata_default_format_is_ndjson(self):
+        args = self._parse_args(["telemetry", "metadata"])
         self.assertEqual("ndjson", args.format)
 
     def test_snapshot_option_completion(self):

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from argcomplete.finders import CompletionFinder
 
+from dp3.bin.cli import init_parser as init_root_parser
 from dp3.bin.sh import init_parser, render_completion_shellcode
 from dp3.bin.shcmd.common import complete_entity_type_names
 
@@ -230,3 +231,9 @@ class TestShCompletion(unittest.TestCase):
         script = render_completion_shellcode("fish", ["dp3", "appsh"])
         self.assertIn("complete --command dp3", script)
         self.assertIn("complete --command appsh", script)
+
+    def test_completion_command_flag_does_not_override_root_command(self):
+        parser = init_root_parser()
+        args = parser.parse_args(["sh", "completion", "zsh", "-c", "dp3"])
+        self.assertEqual("sh", args.command)
+        self.assertEqual(["dp3"], args.completion_commands)

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -1,0 +1,106 @@
+import argparse
+import os
+import unittest
+from unittest.mock import patch
+
+from argcomplete.finders import CompletionFinder
+
+from dp3.bin.sh import init_parser, render_completion_shellcode
+from dp3.bin.shcmd.common import complete_entity_type_names
+
+
+class TestShCompletion(unittest.TestCase):
+    def _create_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(prog="dpsh")
+        init_parser(parser)
+        return parser
+
+    def _get_completions(self, comp_words, prefix):
+        finder = CompletionFinder(self._create_parser(), always_complete_options=False)
+        return finder._get_completions(comp_words, prefix, "", None)
+
+    def test_top_level_completion_includes_entity_commands(self):
+        values = self._get_completions(["dpsh"], "e")
+        self.assertIn("entities", values)
+        self.assertIn("entity", values)
+
+    def test_entity_type_completion_uses_config(self):
+        values = self._get_completions(["dpsh", "--config", "tests/test_config", "entity"], "A")
+        self.assertEqual(["A "], values)
+
+    def test_entity_type_completion_uses_entity_catalog_fallback(self):
+        args = argparse.Namespace(
+            config=os.path.join("tests", "test_common"), url=None, timeout=5.0
+        )
+        with (
+            patch("dp3.bin.shcmd.common.load_completion_model_spec", return_value=None),
+            patch(
+                "dp3.bin.shcmd.common.load_completion_entity_catalog",
+                return_value={"A": {"attribs": ["data1"]}},
+            ),
+        ):
+            values = complete_entity_type_names("A", args)
+        self.assertEqual(["A"], values)
+
+    def test_entity_scope_completion_includes_eid_placeholder(self):
+        values = self._get_completions(["dpsh", "--config", "tests/test_config", "entity", "A"], "")
+        self.assertIn("\\<EID\\>", values)
+        self.assertIn("list", values)
+
+    def test_snapshot_option_completion(self):
+        values = self._get_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "10", "snapshots"],
+            "--",
+        )
+        self.assertIn("--from", values)
+        self.assertIn("--to", values)
+        self.assertIn("--limit", values)
+
+    def test_entity_type_attr_completion_uses_config(self):
+        values = self._get_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "attr"], "d"
+        )
+        self.assertIn("data1", values)
+        self.assertIn("data2", values)
+        self.assertIn("data3", values)
+
+    def test_entity_instance_attr_action_completion(self):
+        values = self._get_completions(
+            [
+                "dpsh",
+                "--config",
+                "tests/test_config",
+                "entity",
+                "A",
+                "entity-1",
+                "attr",
+                "data1",
+            ],
+            "",
+        )
+        self.assertIn("get", values)
+        self.assertIn("set", values)
+
+    def test_type_query_flag_value_completion_uses_attrs(self):
+        values = self._get_completions(
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "list", "--has-attr"],
+            "d",
+        )
+        self.assertIn("data1", values)
+        self.assertIn("data2", values)
+        self.assertIn("data3", values)
+
+    def test_bash_completion_script_registers_commands(self):
+        script = render_completion_shellcode("bash", ["dp3", "appsh"])
+        self.assertIn("complete -o nospace", script)
+        self.assertIn("dp3", script)
+        self.assertIn("appsh", script)
+
+    def test_zsh_completion_script_registers_commands(self):
+        script = render_completion_shellcode("zsh", ["dp3", "appsh"])
+        self.assertIn("compdef _python_argcomplete dp3 appsh", script)
+
+    def test_fish_completion_script_registers_commands(self):
+        script = render_completion_shellcode("fish", ["dp3", "appsh"])
+        self.assertIn("complete --command dp3", script)
+        self.assertIn("complete --command appsh", script)

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -20,6 +20,9 @@ class TestShCompletion(unittest.TestCase):
         values = finder._get_completions(comp_words, prefix, "", None)
         return finder, values
 
+    def _parse_args(self, argv):
+        return self._create_parser().parse_args(argv)
+
     def _get_completions(self, comp_words, prefix):
         return self._finder_with_completions(comp_words, prefix)[1]
 
@@ -64,6 +67,72 @@ class TestShCompletion(unittest.TestCase):
         )
         self.assertIn("--format", values)
         self.assertIn("--limit", values)
+
+    def test_global_short_options_parse(self):
+        args = self._parse_args(
+            ["-c", "tests/test_config", "-u", "http://localhost:5000", "-t", "1.5", "health"]
+        )
+        self.assertEqual("tests/test_config", args.config)
+        self.assertEqual("http://localhost:5000", args.url)
+        self.assertEqual(1.5, args.timeout)
+
+    def test_entity_short_options_parse(self):
+        args = self._parse_args(
+            [
+                "entity",
+                "A",
+                "list",
+                "-q",
+                '{"k":"v"}',
+                "-j",
+                '{"x":1}',
+                "-a",
+                "data1",
+                "-s",
+                "1",
+                "-l",
+                "2",
+                "-F",
+                "ndjson",
+            ]
+        )
+        parsed_args, exit_code = args.prepare_args(args)
+        self.assertIsNone(exit_code)
+        self.assertEqual('{"k":"v"}', parsed_args.fulltext_json)
+        self.assertEqual('{"x":1}', parsed_args.filter_json)
+        self.assertEqual("data1", parsed_args.has_attr)
+        self.assertEqual(1, parsed_args.skip)
+        self.assertEqual(2, parsed_args.limit)
+        self.assertEqual("ndjson", parsed_args.format)
+
+    def test_telemetry_short_options_parse(self):
+        args = self._parse_args(
+            [
+                "telemetry",
+                "metadata",
+                "-m",
+                "SnapShooter",
+                "-f",
+                "2024-01-01",
+                "-t",
+                "2024-01-02",
+                "-s",
+                "1",
+                "-l",
+                "2",
+                "-S",
+                "oldest",
+                "-F",
+                "ndjson",
+            ]
+        )
+        self.assertEqual("SnapShooter", args.module)
+        self.assertEqual("2024-01-01", args.date_from)
+        self.assertEqual("2024-01-02", args.date_to)
+        self.assertEqual(1, args.skip)
+        self.assertEqual(2, args.limit)
+        self.assertEqual("oldest", args.sort)
+        self.assertEqual("ndjson", args.format)
 
     def test_snapshot_option_completion(self):
         values = self._get_completions(

--- a/tests/test_common/test_sh_completion.py
+++ b/tests/test_common/test_sh_completion.py
@@ -71,9 +71,9 @@ class TestShCompletion(unittest.TestCase):
             finder._display_completions.get("--from"),
         )
 
-    def test_entity_type_attr_completion_uses_config(self):
+    def test_entity_type_attr_values_completion_uses_config(self):
         values = self._get_completions(
-            ["dpsh", "--config", "tests/test_config", "entity", "A", "attr"], "d"
+            ["dpsh", "--config", "tests/test_config", "entity", "A", "attr-values"], "d"
         )
         self.assertIn("data1", values)
         self.assertIn("data2", values)


### PR DESCRIPTION
# Add `dp3 sh` and extend the HTTP API for troubleshooting and telemetry

## Summary

This PR adds a new shell-oriented DP3 client, `dp3 sh`, together with a generated per-app wrapper `<APPNAME>sh`.

It also extends the HTTP API so the CLI can cover common troubleshooting and operational reads without falling back to direct database access.

The main pieces are:

- new `dp3 sh ...` CLI
- generated `<APPNAME>sh ...` wrapper from `dp3 config supervisor`
- shell completion support
- HTTP API support for raw datapoint reads, snapshot paging, and broader telemetry reads
- docs updated to prefer `dp3 sh` / `<APPNAME>sh` for routine same-host workflows

The CLI is intentionally API-backed rather than DB-backed. The point is not just to have a convenient operator tool, but also to make the supported HTTP API broad enough to cover real shell workflows.

---

## Why

Before this PR, common troubleshooting often fell into one of these buckets:

- hand-written `curl` requests
- direct `mongosh` queries
- ad hoc telemetry/exporter scripts

That worked, but it meant:

- no first-class CLI consumer of the DP3 API lived in-tree
- some useful reads were only available via database knowledge or one-off scripts
- docs had to jump quickly from high-level usage to raw HTTP or MongoDB examples

This PR addresses that by adding a proper CLI and by extending the HTTP API where needed.

---

## What this PR adds

### 1. New CLI: `dp3 sh`

This PR adds a new command family:

```shell
dp3 sh ...
```

It is designed for shell use:

- JSON/NDJSON output
- command shapes that work well with pipes and `jq`
- entity-oriented inspection commands
- coverage for common entity, control, datapoint, and telemetry workflows

Example commands:

```shell
dp3 sh health
dp3 sh datapoints payload.json

dp3 sh entities | jq keys

dp3 sh entity device list --has-attr risk_score

dp3 sh entity device id device-123 master
dp3 sh entity device id device-123 attr risk_score get
dp3 sh entity device id device-123 snapshots -l 10

dp3 sh telemetry sources-validity
dp3 sh telemetry metadata -F ndjson | head
```

### 2. Generated app wrapper: `<APPNAME>sh`

`dp3 config supervisor` now also generates:

```shell
<APPNAME>sh
```

This gives deployed apps a ready-to-use wrapper with config resolution already wired in.

### 3. Shell completion

This PR adds shell completion support for:

- bash
- zsh
- fish

Completion is config-aware and supports the `dp3 sh` command structure.

### 4. HTTP API extensions

This PR extends the HTTP API so the CLI can expose more of the useful troubleshooting and telemetry surface.

#### Entity/raw inspection

- raw datapoint browsing endpoint for current raw datapoints
- snapshot paging support on entity snapshot reads

#### Telemetry/operational reads

- source age
- entities per attribute
- snapshot summary
- metadata browsing
- RabbitMQ queue telemetry

These API reads replace or subsume several existing script-style operational queries.

### 5. Documentation updates

Docs now prefer `dp3 sh` / `<APPNAME>sh` as the normal same-host workflow, while still keeping:

- `curl` as the raw HTTP fallback
- `mongosh` as the lower-level DB fallback where appropriate

---

## HTTP API changes

### Breaking change

This PR removes the old:

```text
GET /entity/{etype}
```

That endpoint is the main intentional breaking change in this PR.

### Additive/extensions

The rest of the HTTP API work is additive or extends existing reads, especially around:

- entity snapshot paging
- raw datapoint reads
- telemetry and metadata endpoints

In other words, the API surface is broadened for troubleshooting and observability, but the main compatibility change is the removal of the old entity-type endpoint above.

---

## Design notes

### API-backed on purpose

The CLI does not read the database directly. It goes through the HTTP API.

That is intentional because it:

- keeps the CLI aligned with supported API behavior
- forces useful troubleshooting reads to exist as explicit endpoints
- makes the same surface reusable by future clients
- avoids teaching routine users to start with MongoDB internals

### Telemetry intent

The telemetry additions are not just for the CLI.

They also expose operational reads that had previously existed mainly as exporter/helper scripts, so they can be consumed in a supported way through the HTTP API.

---

## Suggested reviewer focus

- whether `dp3 sh` feels like a good first shell client for DP3
- whether the HTTP API additions expose the right raw/telemetry surface
- whether the removal of `GET /entity/{etype}` is acceptable and documented clearly enough
- whether the docs now strike the right balance between `dp3 sh`, `curl`, and `mongosh`